### PR TITLE
chore: remove false positive from lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,4 +46,4 @@ jobs:
           make lint
         env:
           GIT_DIFF: ${{ env.GIT_DIFF }}
-          LINT_DIFF: 1
+          LINT_DIFF: 0


### PR DESCRIPTION
disabling the `LINT_DIFF` env var from lint: #12 