### PR TITLE
chore: skip gosec workflow

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -13,11 +13,14 @@ on:
       - "go.mod"
       - "go.sum"
 
+env:
+  SKIP_WORKFLOW: true  # set to false to enable
+
 jobs:
   Gosec:
     permissions:
       security-events: write
-
+    if: ${{ env.SKIP_WORKFLOW != 'true' }}
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on


### PR DESCRIPTION
`gosec` is throwing a panic when we run into the CI and locally:

`gosec -exclude=G101,G107 -no-fail -fmt sarif -out results.sarif -exclude-generated ./...`

There are three different error messages:
`[gosec] 2025/10/27 15:30:57 Panic when running SSA analyzer on package: keeper. Panic: unexpected CompositeLit type: invalid type`

`[gosec] 2025/10/27 15:30:56 Panic when running SSA analyzer on package: keeper. Panic: runtime error: invalid memory address or nil pointer dereference`

`[gosec] 2025/10/27 15:56:33 Panic when running SSA analyzer on package: v2. Panic: no type for *ast.CallExpr @ ~/Desktop/go/src/github.com/atomone-hub/cosmos-sdk/x/feegrant/migrations/v2/store.go:27:21`

<img width="1321" height="899" alt="Image" src="https://github.com/user-attachments/assets/df27b2ce-5927-42ac-ba2f-643485c347d7" />


I opened an issue in the `gosec` repo: https://github.com/securego/gosec/issues/1410

We will disable it until we have an answer