### PR TITLE
fix: rollback proto files from upgrade module

### DIFF
--- a/proto/cosmos/upgrade/module/v1/module.proto
+++ b/proto/cosmos/upgrade/module/v1/module.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package cosmos.upgrade.module.v1;
+
+import "cosmos/app/v1alpha1/module.proto";
+
+// Module is the config object of the upgrade module.
+message Module {
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "cosmossdk.io/x/upgrade"
+  };
+
+  // authority defines the custom module authority. If not set, defaults to the governance module.
+  string authority = 1;
+}

--- a/proto/cosmos/upgrade/v1beta1/query.proto
+++ b/proto/cosmos/upgrade/v1beta1/query.proto
@@ -1,0 +1,122 @@
+syntax = "proto3";
+package cosmos.upgrade.v1beta1;
+
+import "google/api/annotations.proto";
+import "cosmos/upgrade/v1beta1/upgrade.proto";
+
+option go_package = "cosmossdk.io/x/upgrade/types";
+
+// Query defines the gRPC upgrade querier service.
+service Query {
+  // CurrentPlan queries the current upgrade plan.
+  rpc CurrentPlan(QueryCurrentPlanRequest) returns (QueryCurrentPlanResponse) {
+    option (google.api.http).get = "/cosmos/upgrade/v1beta1/current_plan";
+  }
+
+  // AppliedPlan queries a previously applied upgrade plan by its name.
+  rpc AppliedPlan(QueryAppliedPlanRequest) returns (QueryAppliedPlanResponse) {
+    option (google.api.http).get = "/cosmos/upgrade/v1beta1/applied_plan/{name}";
+  }
+
+  // UpgradedConsensusState queries the consensus state that will serve
+  // as a trusted kernel for the next version of this chain. It will only be
+  // stored at the last height of this chain.
+  // UpgradedConsensusState RPC not supported with legacy querier
+  // This rpc is deprecated now that IBC has its own replacement
+  // (https://github.com/cosmos/ibc-go/blob/2c880a22e9f9cc75f62b527ca94aa75ce1106001/proto/ibc/core/client/v1/query.proto#L54)
+  rpc UpgradedConsensusState(QueryUpgradedConsensusStateRequest) returns (QueryUpgradedConsensusStateResponse) {
+    option deprecated            = true;
+    option (google.api.http).get = "/cosmos/upgrade/v1beta1/upgraded_consensus_state/{last_height}";
+  }
+
+  // ModuleVersions queries the list of module versions from state.
+  //
+  // Since: cosmos-sdk 0.43
+  rpc ModuleVersions(QueryModuleVersionsRequest) returns (QueryModuleVersionsResponse) {
+    option (google.api.http).get = "/cosmos/upgrade/v1beta1/module_versions";
+  }
+
+  // Returns the account with authority to conduct upgrades
+  //
+  // Since: cosmos-sdk 0.46
+  rpc Authority(QueryAuthorityRequest) returns (QueryAuthorityResponse) {
+    option (google.api.http).get = "/cosmos/upgrade/v1beta1/authority";
+  }
+}
+
+// QueryCurrentPlanRequest is the request type for the Query/CurrentPlan RPC
+// method.
+message QueryCurrentPlanRequest {}
+
+// QueryCurrentPlanResponse is the response type for the Query/CurrentPlan RPC
+// method.
+message QueryCurrentPlanResponse {
+  // plan is the current upgrade plan.
+  Plan plan = 1;
+}
+
+// QueryCurrentPlanRequest is the request type for the Query/AppliedPlan RPC
+// method.
+message QueryAppliedPlanRequest {
+  // name is the name of the applied plan to query for.
+  string name = 1;
+}
+
+// QueryAppliedPlanResponse is the response type for the Query/AppliedPlan RPC
+// method.
+message QueryAppliedPlanResponse {
+  // height is the block height at which the plan was applied.
+  int64 height = 1;
+}
+
+// QueryUpgradedConsensusStateRequest is the request type for the Query/UpgradedConsensusState
+// RPC method.
+message QueryUpgradedConsensusStateRequest {
+  option deprecated = true;
+
+  // last height of the current chain must be sent in request
+  // as this is the height under which next consensus state is stored
+  int64 last_height = 1;
+}
+
+// QueryUpgradedConsensusStateResponse is the response type for the Query/UpgradedConsensusState
+// RPC method.
+message QueryUpgradedConsensusStateResponse {
+  option deprecated = true;
+  reserved 1;
+
+  // Since: cosmos-sdk 0.43
+  bytes upgraded_consensus_state = 2;
+}
+
+// QueryModuleVersionsRequest is the request type for the Query/ModuleVersions
+// RPC method.
+//
+// Since: cosmos-sdk 0.43
+message QueryModuleVersionsRequest {
+  // module_name is a field to query a specific module
+  // consensus version from state. Leaving this empty will
+  // fetch the full list of module versions from state
+  string module_name = 1;
+}
+
+// QueryModuleVersionsResponse is the response type for the Query/ModuleVersions
+// RPC method.
+//
+// Since: cosmos-sdk 0.43
+message QueryModuleVersionsResponse {
+  // module_versions is a list of module names with their consensus versions.
+  repeated ModuleVersion module_versions = 1;
+}
+
+// QueryAuthorityRequest is the request type for Query/Authority
+//
+// Since: cosmos-sdk 0.46
+message QueryAuthorityRequest {}
+
+// QueryAuthorityResponse is the response type for Query/Authority
+//
+// Since: cosmos-sdk 0.46
+message QueryAuthorityResponse {
+  string address = 1;
+}

--- a/proto/cosmos/upgrade/v1beta1/tx.proto
+++ b/proto/cosmos/upgrade/v1beta1/tx.proto
@@ -1,0 +1,62 @@
+// Since: cosmos-sdk 0.46
+syntax = "proto3";
+package cosmos.upgrade.v1beta1;
+
+import "gogoproto/gogo.proto";
+import "cosmos_proto/cosmos.proto";
+import "cosmos/upgrade/v1beta1/upgrade.proto";
+import "cosmos/msg/v1/msg.proto";
+import "amino/amino.proto";
+
+option go_package = "cosmossdk.io/x/upgrade/types";
+
+// Msg defines the upgrade Msg service.
+service Msg {
+  option (cosmos.msg.v1.service) = true;
+
+  // SoftwareUpgrade is a governance operation for initiating a software upgrade.
+  //
+  // Since: cosmos-sdk 0.46
+  rpc SoftwareUpgrade(MsgSoftwareUpgrade) returns (MsgSoftwareUpgradeResponse);
+
+  // CancelUpgrade is a governance operation for cancelling a previously
+  // approved software upgrade.
+  //
+  // Since: cosmos-sdk 0.46
+  rpc CancelUpgrade(MsgCancelUpgrade) returns (MsgCancelUpgradeResponse);
+}
+
+// MsgSoftwareUpgrade is the Msg/SoftwareUpgrade request type.
+//
+// Since: cosmos-sdk 0.46
+message MsgSoftwareUpgrade {
+  option (cosmos.msg.v1.signer) = "authority";
+  option (amino.name)           = "cosmos-sdk/MsgSoftwareUpgrade";
+
+  // authority is the address that controls the module (defaults to x/gov unless overwritten).
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+
+  // plan is the upgrade plan.
+  Plan plan = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+}
+
+// MsgSoftwareUpgradeResponse is the Msg/SoftwareUpgrade response type.
+//
+// Since: cosmos-sdk 0.46
+message MsgSoftwareUpgradeResponse {}
+
+// MsgCancelUpgrade is the Msg/CancelUpgrade request type.
+//
+// Since: cosmos-sdk 0.46
+message MsgCancelUpgrade {
+  option (cosmos.msg.v1.signer) = "authority";
+  option (amino.name)           = "cosmos-sdk/MsgCancelUpgrade";
+
+  // authority is the address that controls the module (defaults to x/gov unless overwritten).
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+}
+
+// MsgCancelUpgradeResponse is the Msg/CancelUpgrade response type.
+//
+// Since: cosmos-sdk 0.46
+message MsgCancelUpgradeResponse {}

--- a/proto/cosmos/upgrade/v1beta1/upgrade.proto
+++ b/proto/cosmos/upgrade/v1beta1/upgrade.proto
@@ -1,0 +1,94 @@
+syntax = "proto3";
+package cosmos.upgrade.v1beta1;
+
+import "google/protobuf/any.proto";
+import "gogoproto/gogo.proto";
+import "google/protobuf/timestamp.proto";
+import "cosmos_proto/cosmos.proto";
+import "amino/amino.proto";
+
+option go_package                      = "cosmossdk.io/x/upgrade/types";
+option (gogoproto.goproto_getters_all) = false;
+
+// Plan specifies information about a planned upgrade and when it should occur.
+message Plan {
+  option (amino.name)      = "cosmos-sdk/Plan";
+  option (gogoproto.equal) = true;
+
+  // Sets the name for the upgrade. This name will be used by the upgraded
+  // version of the software to apply any special "on-upgrade" commands during
+  // the first BeginBlock method after the upgrade is applied. It is also used
+  // to detect whether a software version can handle a given upgrade. If no
+  // upgrade handler with this name has been set in the software, it will be
+  // assumed that the software is out-of-date when the upgrade Time or Height is
+  // reached and the software will exit.
+  string name = 1;
+
+  // Deprecated: Time based upgrades have been deprecated. Time based upgrade logic
+  // has been removed from the SDK.
+  // If this field is not empty, an error will be thrown.
+  google.protobuf.Timestamp time = 2
+      [deprecated = true, (gogoproto.stdtime) = true, (gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+
+  // The height at which the upgrade must be performed.
+  int64 height = 3;
+
+  // Any application specific upgrade info to be included on-chain
+  // such as a git commit that validators could automatically upgrade to
+  string info = 4;
+
+  // Deprecated: UpgradedClientState field has been deprecated. IBC upgrade logic has been
+  // moved to the IBC module in the sub module 02-client.
+  // If this field is not empty, an error will be thrown.
+  google.protobuf.Any upgraded_client_state = 5 [deprecated = true];
+}
+
+// SoftwareUpgradeProposal is a gov Content type for initiating a software
+// upgrade.
+// Deprecated: This legacy proposal is deprecated in favor of Msg-based gov
+// proposals, see MsgSoftwareUpgrade.
+message SoftwareUpgradeProposal {
+  option deprecated                          = true;
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
+  option (amino.name)                        = "cosmos-sdk/SoftwareUpgradeProposal";
+  option (gogoproto.equal)                   = true;
+
+  // title of the proposal
+  string title = 1;
+
+  // description of the proposal
+  string description = 2;
+
+  // plan of the proposal
+  Plan plan = 3 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+}
+
+// CancelSoftwareUpgradeProposal is a gov Content type for cancelling a software
+// upgrade.
+// Deprecated: This legacy proposal is deprecated in favor of Msg-based gov
+// proposals, see MsgCancelUpgrade.
+message CancelSoftwareUpgradeProposal {
+  option deprecated                          = true;
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
+  option (amino.name)                        = "cosmos-sdk/CancelSoftwareUpgradeProposal";
+  option (gogoproto.equal)                   = true;
+
+  // title of the proposal
+  string title = 1;
+
+  // description of the proposal
+  string description = 2;
+}
+
+// ModuleVersion specifies a module and its consensus version.
+//
+// Since: cosmos-sdk 0.43
+message ModuleVersion {
+  option (gogoproto.equal) = true;
+
+  // name of the app module
+  string name = 1;
+
+  // consensus version of the app module
+  uint64 version = 2;
+}


### PR DESCRIPTION
The proto files from the upgrade module were accidentally removed. Since we plan to retain the module in the repository, we need to recover them