### PR TITLE
fix: add unhandled error for gov burn deposits and fix lint

### DIFF
--- a/simapp/app_config.go
+++ b/simapp/app_config.go
@@ -14,10 +14,10 @@ import (
 	evidencetypes "cosmossdk.io/x/evidence/types"
 	"cosmossdk.io/x/feegrant"
 	_ "cosmossdk.io/x/feegrant/module" // import for side-effects
-
-	_ "cosmossdk.io/x/upgrade" // import for side-effects
+	_ "cosmossdk.io/x/upgrade"         // import for side-effects
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	upgrademodulev1 "cosmossdk.io/x/upgrade/types/module"
+
 	"github.com/cosmos/cosmos-sdk/runtime"
 	runtimemodule "github.com/cosmos/cosmos-sdk/runtime/module"
 	"github.com/cosmos/cosmos-sdk/types/module"

--- a/simapp/app_di.go
+++ b/simapp/app_di.go
@@ -11,8 +11,8 @@ import (
 	circuitkeeper "cosmossdk.io/x/circuit/keeper"
 	evidencekeeper "cosmossdk.io/x/evidence/keeper"
 	feegrantkeeper "cosmossdk.io/x/feegrant/keeper"
-
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	clienthelpers "github.com/cosmos/cosmos-sdk/client/v2/helpers"

--- a/simapp/app_test.go
+++ b/simapp/app_test.go
@@ -18,8 +18,8 @@ import (
 	"cosmossdk.io/log"
 	"cosmossdk.io/x/evidence"
 	feegrantmodule "cosmossdk.io/x/feegrant/module"
-
 	"cosmossdk.io/x/upgrade"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/testutil/mock"

--- a/simapp/upgrades.go
+++ b/simapp/upgrades.go
@@ -5,8 +5,8 @@ import (
 
 	storetypes "cosmossdk.io/store/types"
 	circuittypes "cosmossdk.io/x/circuit/types"
-
 	upgradetypes "cosmossdk.io/x/upgrade/types"
+
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
 

--- a/tests/e2e/gov/grpc.go
+++ b/tests/e2e/gov/grpc.go
@@ -415,16 +415,16 @@ func (s *E2ETestSuite) TestGetParamsGRPC() {
 				s.Require().Equal(params.Threshold, queryResp.Params.Threshold)
 
 				if tc.checkDeposit {
-					s.Require().NotNil(queryResp.DepositParams)
-					s.Require().Equal(params.MaxDepositPeriod, queryResp.DepositParams.MaxDepositPeriod)
+					s.Require().NotNil(queryResp.DepositParams)                                          //nolint:staticcheck // keep for backward compatibility
+					s.Require().Equal(params.MaxDepositPeriod, queryResp.DepositParams.MaxDepositPeriod) //nolint:staticcheck // keep for backward compatibility
 				}
 				if tc.checkVoting {
-					s.Require().NotNil(queryResp.VotingParams)
-					s.Require().Equal(params.VotingPeriod, queryResp.VotingParams.VotingPeriod)
+					s.Require().NotNil(queryResp.VotingParams)                                  //nolint:staticcheck // keep for backward compatibility
+					s.Require().Equal(params.VotingPeriod, queryResp.VotingParams.VotingPeriod) //nolint:staticcheck // keep for backward compatibility
 				}
 				if tc.checkTally {
-					s.Require().NotNil(queryResp.TallyParams)
-					s.Require().Equal(params.Threshold, queryResp.TallyParams.Threshold)
+					s.Require().NotNil(queryResp.TallyParams)                            //nolint:staticcheck // keep for backward compatibility
+					s.Require().Equal(params.Threshold, queryResp.TallyParams.Threshold) //nolint:staticcheck // keep for backward compatibility
 				}
 			}
 		})

--- a/tests/integration/gov/genesis_test.go
+++ b/tests/integration/gov/genesis_test.go
@@ -173,7 +173,7 @@ func TestImportExportQueues(t *testing.T) {
 	assert.Assert(t, proposal2.Status == v1.StatusVotingPeriod)
 
 	macc := s2.GovKeeper.GetGovernanceAccount(ctx2)
-	assert.DeepEqual(t, sdk.Coins(minDeposit), s2.BankKeeper.GetAllBalances(ctx2, macc.GetAddress()))
+	assert.DeepEqual(t, minDeposit, s2.BankKeeper.GetAllBalances(ctx2, macc.GetAddress()))
 
 	// Run the endblocker. Check to make sure that proposal1 is removed from state, and proposal2 is finished VotingPeriod.
 	err = gov.EndBlocker(ctx2, s2.GovKeeper)

--- a/tests/integration/gov/keeper/tally_test.go
+++ b/tests/integration/gov/keeper/tally_test.go
@@ -90,6 +90,7 @@ func TestTallyOnlyValidatorsAllYes(t *testing.T) {
 	proposal, ok := f.govKeeper.Proposals.Get(ctx, proposalID)
 	assert.Assert(t, ok)
 	passes, burnDeposits, _, tallyResults, err := f.govKeeper.Tally(ctx, proposal)
+	assert.NilError(t, err)
 
 	assert.Assert(t, passes)
 	assert.Assert(t, burnDeposits == false)
@@ -118,7 +119,7 @@ func TestTallyOnlyValidators51No(t *testing.T) {
 	proposal, ok := f.govKeeper.Proposals.Get(ctx, proposalID)
 	assert.Assert(t, ok)
 	passes, burnDeposits, _, _, err := f.govKeeper.Tally(ctx, proposal)
-
+	assert.NilError(t, err)
 	assert.Assert(t, passes == false)
 	assert.Assert(t, burnDeposits == false)
 }
@@ -145,6 +146,7 @@ func TestTallyOnlyValidators51Yes(t *testing.T) {
 	proposal, ok := f.govKeeper.Proposals.Get(ctx, proposalID)
 	assert.Assert(t, ok)
 	passes, burnDeposits, _, tallyResults, err := f.govKeeper.Tally(ctx, proposal)
+	assert.NilError(t, err)
 
 	assert.Assert(t, !passes) // only validators doesn't pass quorum
 	assert.Assert(t, burnDeposits == false)
@@ -204,6 +206,7 @@ func TestTallyOnlyValidatorsAbstainFails(t *testing.T) {
 	proposal, ok := f.govKeeper.Proposals.Get(ctx, proposalID)
 	assert.Assert(t, ok)
 	passes, burnDeposits, _, tallyResults, err := f.govKeeper.Tally(ctx, proposal)
+	assert.NilError(t, err)
 
 	assert.Assert(t, passes == false)
 	assert.Assert(t, burnDeposits == false)
@@ -233,6 +236,7 @@ func TestTallyOnlyValidatorsNonVoter(t *testing.T) {
 	proposal, ok := f.govKeeper.Proposals.Get(ctx, proposalID)
 	assert.Assert(t, ok)
 	passes, burnDeposits, _, tallyResults, err := f.govKeeper.Tally(ctx, proposal)
+	assert.NilError(t, err)
 
 	assert.Assert(t, passes == false)
 	assert.Assert(t, burnDeposits == false)
@@ -272,6 +276,7 @@ func TestTallyDelgatorOverride(t *testing.T) {
 	proposal, ok := f.govKeeper.Proposals.Get(ctx, proposalID)
 	assert.Assert(t, ok)
 	passes, burnDeposits, _, tallyResults, err := f.govKeeper.Tally(ctx, proposal)
+	assert.NilError(t, err)
 
 	assert.Assert(t, passes == false)
 	assert.Assert(t, burnDeposits == false)
@@ -310,6 +315,7 @@ func TestTallyDelgatorInheritDisabled(t *testing.T) {
 	proposal, err = f.govKeeper.Proposals.Get(ctx, proposalID)
 	assert.NilError(t, err)
 	passes, burnDeposits, _, tallyResults, err := f.govKeeper.Tally(ctx, proposal)
+	assert.NilError(t, err)
 
 	assert.Assert(t, !passes) // vote not inherited, proposal not passing
 	assert.Assert(t, burnDeposits == false)
@@ -353,6 +359,7 @@ func TestTallyDelgatorMultipleOverride(t *testing.T) {
 	proposal, ok := f.govKeeper.Proposals.Get(ctx, proposalID)
 	assert.Assert(t, ok)
 	passes, burnDeposits, _, tallyResults, err := f.govKeeper.Tally(ctx, proposal)
+	assert.NilError(t, err)
 
 	assert.Assert(t, passes == false)
 	assert.Assert(t, burnDeposits == false)
@@ -397,6 +404,7 @@ func TestTallyDelgatorMultipleInherit(t *testing.T) {
 	proposal, ok := f.govKeeper.Proposals.Get(ctx, proposalID)
 	assert.Assert(t, ok)
 	passes, burnDeposits, _, tallyResults, err := f.govKeeper.Tally(ctx, proposal)
+	assert.NilError(t, err)
 
 	assert.Assert(t, passes == false)
 	assert.Assert(t, burnDeposits == false)
@@ -443,6 +451,7 @@ func TestTallyJailedValidator(t *testing.T) {
 	proposal, ok := f.govKeeper.Proposals.Get(ctx, proposalID)
 	assert.Assert(t, ok)
 	passes, burnDeposits, _, tallyResults, err := f.govKeeper.Tally(ctx, proposal)
+	assert.NilError(t, err)
 
 	assert.Assert(t, passes)
 	assert.Assert(t, burnDeposits == false)
@@ -479,6 +488,7 @@ func TestTallyValidatorMultipleDelegations(t *testing.T) {
 	proposal, ok := f.govKeeper.Proposals.Get(ctx, proposalID)
 	assert.Assert(t, ok)
 	passes, burnDeposits, _, tallyResults, err := f.govKeeper.Tally(ctx, proposal)
+	assert.NilError(t, err)
 
 	assert.Assert(t, passes)
 	assert.Assert(t, burnDeposits == false)

--- a/tests/integration/gov/keeper/tally_test.go
+++ b/tests/integration/gov/keeper/tally_test.go
@@ -175,7 +175,9 @@ func TestTallyOnlyValidatorsAbstain(t *testing.T) {
 
 	proposal, ok := f.govKeeper.Proposals.Get(ctx, proposalID)
 	assert.Assert(t, ok)
+
 	passes, burnDeposits, participation, tallyResults, err := f.govKeeper.Tally(ctx, proposal)
+	assert.NilError(t, err)
 
 	assert.Assert(t, !passes)
 	assert.Assert(t, burnDeposits == false)

--- a/x/gov/abci.go
+++ b/x/gov/abci.go
@@ -233,7 +233,10 @@ func EndBlocker(ctx sdk.Context, keeper *keeper.Keeper) error {
 		} else {
 			err = keeper.RefundAndDeleteDeposits(ctx, proposal.Id)
 		}
-
+		if err != nil {
+			return false, err
+		}
+		
 		if err = keeper.ActiveProposalsQueue.Remove(ctx, collections.Join(*proposal.VotingEndTime, proposal.Id)); err != nil {
 			return false, err
 		}

--- a/x/gov/abci.go
+++ b/x/gov/abci.go
@@ -236,7 +236,7 @@ func EndBlocker(ctx sdk.Context, keeper *keeper.Keeper) error {
 		if err != nil {
 			return false, err
 		}
-		
+
 		if err = keeper.ActiveProposalsQueue.Remove(ctx, collections.Join(*proposal.VotingEndTime, proposal.Id)); err != nil {
 			return false, err
 		}

--- a/x/gov/client/cli/query.go
+++ b/x/gov/client/cli/query.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/version"
-
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
@@ -50,7 +49,7 @@ $ %s query gov quorums
 			),
 		),
 		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
@@ -88,7 +87,7 @@ $ %s query gov min-deposit
 				version.AppName,
 			),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
@@ -124,7 +123,7 @@ $ %s query gov min-initial-deposit
 				version.AppName,
 			),
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
@@ -160,7 +159,7 @@ $ %s query gov participation
 			),
 		),
 		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err

--- a/x/gov/client/utils/query.go
+++ b/x/gov/client/utils/query.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
-	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	"github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 )
 

--- a/x/gov/client/utils/unified_diff_test.go
+++ b/x/gov/client/utils/unified_diff_test.go
@@ -4,9 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cosmos/cosmos-sdk/x/gov/client/utils"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateUnifiedDiff(t *testing.T) {

--- a/x/gov/keeper/constitution.go
+++ b/x/gov/keeper/constitution.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 
 	"cosmossdk.io/collections"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 )
 

--- a/x/gov/keeper/deposit.go
+++ b/x/gov/keeper/deposit.go
@@ -304,7 +304,7 @@ func (keeper Keeper) validateInitialDeposit(ctx context.Context, params v1.Param
 }
 
 // validateDepositDenom validates if the deposit denom is accepted by the governance module.
-func (keeper Keeper) validateDepositDenom(ctx context.Context, params v1.Params, depositAmount sdk.Coins) error {
+func (keeper Keeper) validateDepositDenom(_ context.Context, params v1.Params, depositAmount sdk.Coins) error {
 	// Use the floor value from MinDepositThrottler to determine accepted denoms
 	// The floor defines which denominations are acceptable
 	acceptedCoins := params.MinDepositThrottler.FloorValue

--- a/x/gov/keeper/deposit.go
+++ b/x/gov/keeper/deposit.go
@@ -289,7 +289,7 @@ func (keeper Keeper) RefundAndDeleteDeposits(ctx context.Context, proposalID uin
 // validateInitialDeposit validates if initial deposit is greater than or equal to the minimum
 // required at the time of proposal submission. This threshold amount is determined by
 // the deposit parameters. Returns nil on success, error otherwise.
-func (keeper Keeper) validateInitialDeposit(ctx context.Context, params v1.Params, initialDeposit sdk.Coins) error {
+func (keeper Keeper) validateInitialDeposit(ctx context.Context, _ v1.Params, initialDeposit sdk.Coins) error {
 	if !initialDeposit.IsValid() || initialDeposit.IsAnyNegative() {
 		return errors.Wrap(sdkerrors.ErrInvalidCoins, initialDeposit.String())
 	}

--- a/x/gov/keeper/grpc_query.go
+++ b/x/gov/keeper/grpc_query.go
@@ -287,7 +287,7 @@ func (q queryServer) TallyResult(ctx context.Context, req *v1.QueryTallyResultRe
 }
 
 // MinDeposit returns the minimum deposit currently required for a proposal to enter voting period
-func (q queryServer) MinDeposit(c context.Context, req *v1.QueryMinDepositRequest) (*v1.QueryMinDepositResponse, error) {
+func (q queryServer) MinDeposit(c context.Context, _ *v1.QueryMinDepositRequest) (*v1.QueryMinDepositResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 	minDeposit := q.k.GetMinDeposit(ctx)
 
@@ -295,7 +295,7 @@ func (q queryServer) MinDeposit(c context.Context, req *v1.QueryMinDepositReques
 }
 
 // MinInitialDeposit returns the minimum deposit required for a proposal to be submitted
-func (q queryServer) MinInitialDeposit(c context.Context, req *v1.QueryMinInitialDepositRequest) (*v1.QueryMinInitialDepositResponse, error) {
+func (q queryServer) MinInitialDeposit(c context.Context, _ *v1.QueryMinInitialDepositRequest) (*v1.QueryMinInitialDepositResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 	minInitialDeposit := q.k.GetMinInitialDeposit(ctx)
 

--- a/x/gov/keeper/grpc_query_test.go
+++ b/x/gov/keeper/grpc_query_test.go
@@ -875,6 +875,7 @@ func (suite *KeeperTestSuite) TestLegacyGRPCQueryVotes() {
 	}
 }
 
+//nolint:staticcheck // keep for backward compatibility
 func (suite *KeeperTestSuite) TestGRPCQueryParams() {
 	queryClient := suite.queryClient
 

--- a/x/gov/keeper/grpc_query_test.go
+++ b/x/gov/keeper/grpc_query_test.go
@@ -875,7 +875,7 @@ func (suite *KeeperTestSuite) TestLegacyGRPCQueryVotes() {
 	}
 }
 
-//nolint:staticcheck // keep for backward compatibility
+//nolint:staticcheck,goconst // keep for backward compatibility
 func (suite *KeeperTestSuite) TestGRPCQueryParams() {
 	queryClient := suite.queryClient
 

--- a/x/gov/keeper/min_deposit.go
+++ b/x/gov/keeper/min_deposit.go
@@ -10,7 +10,6 @@ import (
 	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
@@ -73,7 +72,7 @@ func (keeper Keeper) UpdateMinDeposit(ctx context.Context, checkElapsedTime bool
 	var alpha math.LegacyDec
 
 	var countActiveProposals uint64
-	err = keeper.ActiveProposalsQueue.Walk(ctx, nil, func(key collections.Pair[time.Time, uint64], _ uint64) (bool, error) {
+	err = keeper.ActiveProposalsQueue.Walk(ctx, nil, func(collections.Pair[time.Time, uint64], uint64) (bool, error) {
 		countActiveProposals++
 		return false, nil
 	})

--- a/x/gov/keeper/min_deposit_test.go
+++ b/x/gov/keeper/min_deposit_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 	"time"
 
-	"cosmossdk.io/math"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	"cosmossdk.io/math"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )

--- a/x/gov/keeper/min_initial_deposit.go
+++ b/x/gov/keeper/min_initial_deposit.go
@@ -10,7 +10,6 @@ import (
 	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
@@ -75,7 +74,7 @@ func (keeper Keeper) UpdateMinInitialDeposit(ctx context.Context, checkElapsedTi
 	var alpha math.LegacyDec
 
 	var countInactiveProposals uint64
-	err = keeper.InactiveProposalsQueue.Walk(ctx, nil, func(key collections.Pair[time.Time, uint64], _ uint64) (bool, error) {
+	err = keeper.InactiveProposalsQueue.Walk(ctx, nil, func(collections.Pair[time.Time, uint64], uint64) (bool, error) {
 		countInactiveProposals++
 		return false, nil
 	})

--- a/x/gov/keeper/min_initial_deposit_test.go
+++ b/x/gov/keeper/min_initial_deposit_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 	"time"
 
-	"cosmossdk.io/math"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	"cosmossdk.io/math"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )

--- a/x/gov/keeper/msg_server.go
+++ b/x/gov/keeper/msg_server.go
@@ -309,7 +309,7 @@ func (k msgServer) UpdateParams(goCtx context.Context, msg *v1.MsgUpdateParams) 
 }
 
 // ProposeLaw implements the MsgServer.ProposeLaw method.
-func (k msgServer) ProposeLaw(goCtx context.Context, msg *v1.MsgProposeLaw) (*v1.MsgProposeLawResponse, error) {
+func (k msgServer) ProposeLaw(_ context.Context, msg *v1.MsgProposeLaw) (*v1.MsgProposeLawResponse, error) {
 	if k.authority != msg.Authority {
 		return nil, errors.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", k.authority, msg.Authority)
 	}

--- a/x/gov/keeper/participation_ema.go
+++ b/x/gov/keeper/participation_ema.go
@@ -13,8 +13,8 @@ import (
 
 // UpdateParticipationEMA updates the governance participation EMA
 func (k Keeper) UpdateParticipationEMA(ctx context.Context, proposal v1.Proposal, participation math.LegacyDec) {
-	formula := func(old, new math.LegacyDec) math.LegacyDec {
-		return old.Mul(math.LegacyNewDecWithPrec(8, 1)).Add(new.Mul(math.LegacyNewDecWithPrec(2, 1)))
+	formula := func(oldValue, newValue math.LegacyDec) math.LegacyDec {
+		return oldValue.Mul(math.LegacyNewDecWithPrec(8, 1)).Add(newValue.Mul(math.LegacyNewDecWithPrec(2, 1)))
 	}
 
 	kinds := k.ProposalKinds(proposal)

--- a/x/gov/keeper/participation_ema_test.go
+++ b/x/gov/keeper/participation_ema_test.go
@@ -3,12 +3,13 @@ package keeper_test
 import (
 	"testing"
 
-	"cosmossdk.io/math"
-	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/stretchr/testify/assert"
+
+	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
 
 func TestGetSetParticipationEma(t *testing.T) {

--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -274,14 +274,14 @@ func (keeper Keeper) ActivateVotingPeriod(ctx context.Context, proposal v1.Propo
 
 // ProposalKinds returns a v1.ProposalKinds useful to determine which kind of
 // messages are included in a proposal.
-func (k Keeper) ProposalKinds(p v1.Proposal) v1.ProposalKinds {
+func (keeper Keeper) ProposalKinds(p v1.Proposal) v1.ProposalKinds {
 	if len(p.Messages) == 0 {
 		return v1.ProposalKindAny
 	}
 	var kinds v1.ProposalKinds
 	for _, msg := range p.Messages {
 		var sdkMsg sdk.Msg
-		if err := k.cdc.UnpackAny(msg, &sdkMsg); err == nil {
+		if err := keeper.cdc.UnpackAny(msg, &sdkMsg); err == nil {
 			switch sdkMsg.(type) {
 			case *v1.MsgProposeConstitutionAmendment:
 				kinds |= v1.ProposalKindConstitutionAmendment

--- a/x/gov/keeper/proposal_test.go
+++ b/x/gov/keeper/proposal_test.go
@@ -27,7 +27,6 @@ func (suite *KeeperTestSuite) TestGetSetProposal() {
 	gotProposal, err := suite.govKeeper.Proposals.Get(suite.ctx, proposalID)
 	suite.Require().Nil(err)
 	suite.Require().Equal(proposal, gotProposal)
-
 }
 
 // TODO(tip): remove this
@@ -65,7 +64,6 @@ func (suite *KeeperTestSuite) TestActivateVotingPeriod() {
 }
 
 func (suite *KeeperTestSuite) TestDeleteProposalInVotingPeriod() {
-
 	suite.reset()
 	tp := TestProposal
 	proposal, err := suite.govKeeper.SubmitProposal(suite.ctx, tp, "", "test", "summary", suite.addrs[0])

--- a/x/gov/keeper/tally.go
+++ b/x/gov/keeper/tally.go
@@ -164,7 +164,7 @@ func (keeper Keeper) tallyVotes(
 		}
 
 		// iterate over all delegations from voter, deduct from any delegated-to validators
-		err = keeper.sk.IterateDelegations(ctx, voter, func(index int64, delegation stakingtypes.DelegationI) (stop bool) {
+		err = keeper.sk.IterateDelegations(ctx, voter, func(_ int64, delegation stakingtypes.DelegationI) (stop bool) {
 			valAddrStr := delegation.GetValidatorAddr()
 
 			if val, ok := currValidators[valAddrStr]; ok {

--- a/x/gov/keeper/tally.go
+++ b/x/gov/keeper/tally.go
@@ -8,15 +8,14 @@ import (
 	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 // Tally iterates over the votes and updates the tally of a proposal based on the voting power of the
 // voters
 // CONTRACT: passes is always false when err!=nil
-func (keeper Keeper) Tally(ctx context.Context, proposal v1.Proposal) (passes bool, burnDeposits bool, participation math.LegacyDec, tallyResults v1.TallyResult, err error) {
+func (keeper Keeper) Tally(ctx context.Context, proposal v1.Proposal) (passes, burnDeposits bool, participation math.LegacyDec, tallyResults v1.TallyResult, err error) {
 	// fetch all the bonded validators
 	currValidators, err := keeper.getBondedValidatorsByAddress(ctx)
 	if err != nil {
@@ -133,7 +132,7 @@ func (keeper Keeper) HasReachedQuorum(ctx sdk.Context, proposal v1.Proposal) (bo
 // them in map using their operator address as the key.
 func (keeper Keeper) getBondedValidatorsByAddress(ctx context.Context) (map[string]stakingtypes.ValidatorI, error) {
 	vals := make(map[string]stakingtypes.ValidatorI)
-	err := keeper.sk.IterateBondedValidatorsByPower(ctx, func(index int64, validator stakingtypes.ValidatorI) (stop bool) {
+	err := keeper.sk.IterateBondedValidatorsByPower(ctx, func(_ int64, validator stakingtypes.ValidatorI) (stop bool) {
 		vals[validator.GetOperator()] = validator
 		return false
 	})
@@ -225,7 +224,7 @@ func (keeper Keeper) tallyVotes(
 // getQuorumAndThreshold returns the appropriate quorum and threshold according
 // to proposal kind. If the proposal contains multiple kinds, the highest
 // quorum and threshold is returned.
-func (keeper Keeper) getQuorumAndThreshold(ctx context.Context, proposal v1.Proposal) (quorum math.LegacyDec, threshold math.LegacyDec) {
+func (keeper Keeper) getQuorumAndThreshold(ctx context.Context, proposal v1.Proposal) (quorum, threshold math.LegacyDec) {
 	params, err := keeper.Params.Get(ctx)
 	if err != nil {
 		return math.LegacyZeroDec(), math.LegacyZeroDec()

--- a/x/gov/keeper/tally_test.go
+++ b/x/gov/keeper/tally_test.go
@@ -13,11 +13,10 @@ import (
 
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-
 	"github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	govtestutil "github.com/cosmos/cosmos-sdk/x/gov/testutil"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 type tallyFixture struct {

--- a/x/gov/migrations/v3/convert.go
+++ b/x/gov/migrations/v3/convert.go
@@ -8,7 +8,6 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 )
@@ -127,47 +126,4 @@ func ConvertToLegacyDeposit(deposit *v1.Deposit) v1beta1.Deposit {
 		Depositor:  deposit.Depositor,
 		Amount:     types.NewCoins(deposit.Amount...),
 	}
-}
-
-func convertToNewProposal(oldProp v1beta1.Proposal) (v1.Proposal, error) {
-	msg, err := v1.NewLegacyContent(oldProp.GetContent(), authtypes.NewModuleAddress("gov").String())
-	if err != nil {
-		return v1.Proposal{}, err
-	}
-	msgAny, err := codectypes.NewAnyWithValue(msg)
-	if err != nil {
-		return v1.Proposal{}, err
-	}
-
-	return v1.Proposal{
-		Id:       oldProp.ProposalId,
-		Messages: []*codectypes.Any{msgAny},
-		Status:   v1.ProposalStatus(oldProp.Status),
-		FinalTallyResult: &v1.TallyResult{
-			YesCount:     oldProp.FinalTallyResult.Yes.String(),
-			NoCount:      oldProp.FinalTallyResult.No.String(),
-			AbstainCount: oldProp.FinalTallyResult.Abstain.String(),
-		},
-		SubmitTime:      &oldProp.SubmitTime,
-		DepositEndTime:  &oldProp.DepositEndTime,
-		TotalDeposit:    oldProp.TotalDeposit,
-		VotingStartTime: &oldProp.VotingStartTime,
-		VotingEndTime:   &oldProp.VotingEndTime,
-		Title:           oldProp.GetContent().GetTitle(),
-		Summary:         oldProp.GetContent().GetDescription(),
-	}, nil
-}
-
-func convertToNewProposals(oldProps v1beta1.Proposals) (v1.Proposals, error) {
-	newProps := make([]*v1.Proposal, len(oldProps))
-	for i, oldProp := range oldProps {
-		p, err := convertToNewProposal(oldProp)
-		if err != nil {
-			return nil, err
-		}
-
-		newProps[i] = &p
-	}
-
-	return newProps, nil
 }

--- a/x/gov/migrations/v5/store.go
+++ b/x/gov/migrations/v5/store.go
@@ -88,7 +88,7 @@ func MigrateStore(
 		}
 	}
 
-	// Set the default consitution if it is not set
+	// Set the default constitution if it is not set
 	if ok, err := constitutionItem.Has(ctx); !ok || err != nil {
 		if err := constitutionItem.Set(ctx, "This chain has no constitution."); err != nil {
 			return err

--- a/x/gov/simulation/genesis.go
+++ b/x/gov/simulation/genesis.go
@@ -13,9 +13,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/types/simulation"
-
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
-	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	"github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
 
 // Simulation parameter constants
@@ -79,14 +78,14 @@ func GenTallyParamsThreshold(r *rand.Rand) math.LegacyDec {
 }
 
 // GenMinDepositRatio returns randomized DepositMinRatio
-func GenMinDepositRatio(r *rand.Rand) math.LegacyDec {
+func GenMinDepositRatio(*rand.Rand) math.LegacyDec {
 	return math.LegacyMustNewDecFromStr("0.01")
 }
 
-// GenTallyParamsThreshold returns randomized TallyParamsConstitutionalThreshold
+// GenTallyParamsConstitutionalThreshold returns randomized TallyParamsConstitutionalThreshold
 func GenTallyParamsConstitutionalThreshold(r *rand.Rand, minDec math.LegacyDec) math.LegacyDec {
-	min := int(minDec.Mul(math.LegacyNewDec(1000)).RoundInt64())
-	return math.LegacyNewDecWithPrec(int64(simulation.RandIntBetween(r, min, 950)), 3)
+	minimum := int(minDec.Mul(math.LegacyNewDec(1000)).RoundInt64())
+	return math.LegacyNewDecWithPrec(int64(simulation.RandIntBetween(r, minimum, 950)), 3)
 }
 
 // GenQuorumTimeout returns a randomized QuorumTimeout between 0 and votingPeriod
@@ -126,11 +125,11 @@ func GenDepositParamsMinDepositSensitivityTargetDistance(r *rand.Rand) uint64 {
 }
 
 // GenDepositParamsMinDepositChangeRatio returns randomized DepositParamsMinDepositChangeRatio
-func GenDepositParamsMinDepositChangeRatio(r *rand.Rand, max, prec int) math.LegacyDec {
-	if max <= 0 {
+func GenDepositParamsMinDepositChangeRatio(r *rand.Rand, maximum, prec int) math.LegacyDec {
+	if maximum <= 0 {
 		return math.LegacyZeroDec()
 	}
-	return math.LegacyNewDecWithPrec(int64(simulation.RandIntBetween(r, 0, max)), int64(prec))
+	return math.LegacyNewDecWithPrec(int64(simulation.RandIntBetween(r, 0, maximum)), int64(prec))
 }
 
 // GenDepositParamsTargetActiveProposals returns randomized DepositParamsTargetActiveProposals
@@ -149,11 +148,11 @@ func GenDepositParamsMinInitialDepositSensitivityTargetDistance(r *rand.Rand) ui
 }
 
 // GenDepositParamsMinInitialDepositChangeRatio returns randomized DepositParamsMinInitialDepositChangeRatio
-func GenDepositParamsMinInitialDepositChangeRatio(r *rand.Rand, max, prec int) math.LegacyDec {
-	if max <= 0 {
+func GenDepositParamsMinInitialDepositChangeRatio(r *rand.Rand, maximum, prec int) math.LegacyDec {
+	if maximum <= 0 {
 		return math.LegacyZeroDec()
 	}
-	return math.LegacyNewDecWithPrec(int64(simulation.RandIntBetween(r, 0, max)), int64(prec))
+	return math.LegacyNewDecWithPrec(int64(simulation.RandIntBetween(r, 0, maximum)), int64(prec))
 }
 
 func GenDepositParamsMinInitialDepositTargetProposals(r *rand.Rand) uint64 {

--- a/x/gov/simulation/genesis_test.go
+++ b/x/gov/simulation/genesis_test.go
@@ -15,7 +15,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
-
 	"github.com/cosmos/cosmos-sdk/x/gov/simulation"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"

--- a/x/gov/types/unified_diff.go
+++ b/x/gov/types/unified_diff.go
@@ -119,7 +119,7 @@ func parseHunkHeader(header string) (*Hunk, error) {
 }
 
 // parseHunkRange parses a range string like "-srcLine,srcSpan" or "+dstLine"
-func parseHunkRange(rangeStr string) (line int, span int, err error) {
+func parseHunkRange(rangeStr string) (line, span int, err error) {
 	if len(rangeStr) == 0 {
 		return 0, 0, fmt.Errorf("empty range string")
 	}

--- a/x/gov/types/v1/genesis.go
+++ b/x/gov/types/v1/genesis.go
@@ -50,24 +50,24 @@ func ValidateGenesis(data *GenesisState) error {
 	var errGroup errgroup.Group
 
 	// weed out duplicate proposals
-	proposalIds := make(map[uint64]struct{})
+	proposalIDs := make(map[uint64]struct{})
 	for _, p := range data.Proposals {
-		if _, ok := proposalIds[p.Id]; ok {
+		if _, ok := proposalIDs[p.Id]; ok {
 			return fmt.Errorf("duplicate proposal id: %d", p.Id)
 		}
 
-		proposalIds[p.Id] = struct{}{}
+		proposalIDs[p.Id] = struct{}{}
 	}
 
 	// weed out duplicate deposits
 	errGroup.Go(func() error {
 		type depositKey struct {
-			ProposalId uint64
+			proposalID uint64
 			Depositor  string
 		}
 		depositIds := make(map[depositKey]struct{})
 		for _, d := range data.Deposits {
-			if _, ok := proposalIds[d.ProposalId]; !ok {
+			if _, ok := proposalIDs[d.ProposalId]; !ok {
 				return fmt.Errorf("deposit %v has non-existent proposal id: %d", d, d.ProposalId)
 			}
 
@@ -85,21 +85,21 @@ func ValidateGenesis(data *GenesisState) error {
 	// weed out duplicate votes
 	errGroup.Go(func() error {
 		type voteKey struct {
-			ProposalId uint64
+			proposalID uint64
 			Voter      string
 		}
-		voteIds := make(map[voteKey]struct{})
+		voteIDs := make(map[voteKey]struct{})
 		for _, v := range data.Votes {
-			if _, ok := proposalIds[v.ProposalId]; !ok {
+			if _, ok := proposalIDs[v.ProposalId]; !ok {
 				return fmt.Errorf("vote %v has non-existent proposal id: %d", v, v.ProposalId)
 			}
 
 			vk := voteKey{v.ProposalId, v.Voter}
-			if _, ok := voteIds[vk]; ok {
+			if _, ok := voteIDs[vk]; ok {
 				return fmt.Errorf("duplicate vote: %v", v)
 			}
 
-			voteIds[vk] = struct{}{}
+			voteIDs[vk] = struct{}{}
 		}
 
 		return nil

--- a/x/gov/types/v1/genesis.go
+++ b/x/gov/types/v1/genesis.go
@@ -65,18 +65,18 @@ func ValidateGenesis(data *GenesisState) error {
 			proposalID uint64
 			Depositor  string
 		}
-		depositIds := make(map[depositKey]struct{})
+		depositIDs := make(map[depositKey]struct{})
 		for _, d := range data.Deposits {
 			if _, ok := proposalIDs[d.ProposalId]; !ok {
 				return fmt.Errorf("deposit %v has non-existent proposal id: %d", d, d.ProposalId)
 			}
 
 			dk := depositKey{d.ProposalId, d.Depositor}
-			if _, ok := depositIds[dk]; ok {
+			if _, ok := depositIDs[dk]; ok {
 				return fmt.Errorf("duplicate deposit: %v", d)
 			}
 
-			depositIds[dk] = struct{}{}
+			depositIDs[dk] = struct{}{}
 		}
 
 		return nil

--- a/x/gov/types/v1/genesis_test.go
+++ b/x/gov/types/v1/genesis_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 	"time"
 
-	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	"cosmossdk.io/math"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
 

--- a/x/gov/types/v1/min_deposit_test.go
+++ b/x/gov/types/v1/min_deposit_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/math"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -53,23 +53,23 @@ var (
 	DefaultBurnVoteQuorom      = false                           // set to false to  replicate behavior of when this change was made (0.47)
 	DefaultMinDepositRatio     = math.LegacyNewDecWithPrec(1, 2) // NOTE: backport from v50
 
-	DefaultQuorumTimeout                                      time.Duration = DefaultVotingPeriod - (time.Hour * 24 * 1) // disabled by default (DefaultQuorumCheckCount must be set to a non-zero value to enable)
-	DefaultMaxVotingPeriodExtension                           time.Duration = DefaultVotingPeriod - DefaultQuorumTimeout // disabled by default (DefaultQuorumCheckCount must be set to a non-zero value to enable)
-	DefaultQuorumCheckCount                                   uint64        = 0                                          // disabled by default (0 means no check)
-	DefaultMinDepositUpdatePeriod                             time.Duration = time.Hour * 24 * 7
-	DefaultMinDepositDecreaseSensitivityTargetDistance        uint64        = 2
-	DefaultMinDepositIncreaseRatio                                          = math.LegacyNewDecWithPrec(5, 2)
-	DefaultMinDepositDecreaseRatio                                          = math.LegacyNewDecWithPrec(25, 3)
-	DefaultTargetActiveProposals                              uint64        = 2
-	DefaultMinInitialDepositFloorAmount                       math.Int      = math.LegacyNewDecWithPrec(1, 2).MulInt(DefaultMinDepositTokens).TruncateInt()
-	DefaultMinInitialDepositUpdatePeriod                      time.Duration = time.Hour * 24
-	DefaultMinInitialDepositDecreaseSensitivityTargetDistance uint64        = 2
-	DefaultMinInitialDepositIncreaseRatio                                   = math.LegacyNewDecWithPrec(1, 2)
-	DefaultMinInitialDepositDecreaseRatio                                   = math.LegacyNewDecWithPrec(5, 3)
-	DefaultTargetProposalsInDepositPeriod                     uint64        = 5
-	DefaultBurnDepositNoThreshold                                           = math.LegacyNewDecWithPrec(80, 2)
-	DefaultProposalCancelRatio                                              = math.LegacyMustNewDecFromStr("0.5")
-	DefaultProposalCancelDestAddress                                        = ""
+	DefaultQuorumTimeout                                             = DefaultVotingPeriod - (time.Hour * 24 * 1) // disabled by default (DefaultQuorumCheckCount must be set to a non-zero value to enable)
+	DefaultMaxVotingPeriodExtension                                  = DefaultVotingPeriod - DefaultQuorumTimeout // disabled by default (DefaultQuorumCheckCount must be set to a non-zero value to enable)
+	DefaultQuorumCheckCount                                   uint64 = 0                                          // disabled by default (0 means no check)
+	DefaultMinDepositUpdatePeriod                                    = time.Hour * 24 * 7
+	DefaultMinDepositDecreaseSensitivityTargetDistance        uint64 = 2
+	DefaultMinDepositIncreaseRatio                                   = math.LegacyNewDecWithPrec(5, 2)
+	DefaultMinDepositDecreaseRatio                                   = math.LegacyNewDecWithPrec(25, 3)
+	DefaultTargetActiveProposals                              uint64 = 2
+	DefaultMinInitialDepositFloorAmount                              = math.LegacyNewDecWithPrec(1, 2).MulInt(DefaultMinDepositTokens).TruncateInt()
+	DefaultMinInitialDepositUpdatePeriod                             = time.Hour * 24
+	DefaultMinInitialDepositDecreaseSensitivityTargetDistance uint64 = 2
+	DefaultMinInitialDepositIncreaseRatio                            = math.LegacyNewDecWithPrec(1, 2)
+	DefaultMinInitialDepositDecreaseRatio                            = math.LegacyNewDecWithPrec(5, 3)
+	DefaultTargetProposalsInDepositPeriod                     uint64 = 5
+	DefaultBurnDepositNoThreshold                                    = math.LegacyNewDecWithPrec(80, 2)
+	DefaultProposalCancelRatio                                       = math.LegacyMustNewDecFromStr("0.5")
+	DefaultProposalCancelDestAddress                                 = ""
 )
 
 // Deprecated: NewDepositParams creates a new DepositParams object

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -55,7 +55,7 @@ var (
 
 	DefaultQuorumTimeout                                             = DefaultVotingPeriod - (time.Hour * 24 * 1) // disabled by default (DefaultQuorumCheckCount must be set to a non-zero value to enable)
 	DefaultMaxVotingPeriodExtension                                  = DefaultVotingPeriod - DefaultQuorumTimeout // disabled by default (DefaultQuorumCheckCount must be set to a non-zero value to enable)
-	DefaultQuorumCheckCount                                   uint64 = 0                                          // disabled by default (0 means no check)
+	DefaultQuorumCheckCount                                   uint64 = 0                                          //nolint:revive // disabled by default (0 means no check)
 	DefaultMinDepositUpdatePeriod                                    = time.Hour * 24 * 7
 	DefaultMinDepositDecreaseSensitivityTargetDistance        uint64 = 2
 	DefaultMinDepositIncreaseRatio                                   = math.LegacyNewDecWithPrec(5, 2)

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -115,9 +115,9 @@ func NewParams(
 	minInitialDepositFloor sdk.Coins, minInitialDepositUpdatePeriod time.Duration, minInitialDepositDecreaseSensitivityTargetDistance uint64,
 	minInitialDepositIncreaseRatio, minInitialDepositDecreaseRatio string, targetProposalsInDepositPeriod uint64,
 	burnDepositNoThreshold string,
-	maxQuorum string, minQuorum string,
-	maxConstitutionAmendmentQuorum string, minConstitutionAmendmentQuorum string,
-	maxLawQuorum string, minLawQuorum string,
+	maxQuorum, minQuorum string,
+	maxConstitutionAmendmentQuorum, minConstitutionAmendmentQuorum string,
+	maxLawQuorum, minLawQuorum string,
 	proposalCancelRatio, proposalCancelDest string,
 ) Params {
 	return Params{

--- a/x/gov/types/v1/proposal.go
+++ b/x/gov/types/v1/proposal.go
@@ -126,10 +126,10 @@ func ProposalStatusFromString(str string) (ProposalStatus, error) {
 func (status ProposalStatus) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 's':
-		s.Write([]byte(status.String())) //nolint:errcheck
+		s.Write([]byte(status.String())) //nolint:errcheck // unhandled error
 	default:
 		// TODO: Do this conversion more directly
-		s.Write([]byte(fmt.Sprintf("%v", byte(status)))) //nolint:errcheck
+		s.Write([]byte(fmt.Sprintf("%v", byte(status)))) //nolint:errcheck // unhandled error
 	}
 }
 

--- a/x/gov/types/v1/proposals_test.go
+++ b/x/gov/types/v1/proposals_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 )

--- a/x/upgrade/abci.go
+++ b/x/upgrade/abci.go
@@ -7,9 +7,9 @@ import (
 
 	"cosmossdk.io/core/appmodule"
 	storetypes "cosmossdk.io/store/types"
-
 	"cosmossdk.io/x/upgrade/keeper"
 	"cosmossdk.io/x/upgrade/types"
+
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/x/upgrade/abci_test.go
+++ b/x/upgrade/abci_test.go
@@ -14,10 +14,10 @@ import (
 	"cosmossdk.io/core/header"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
-
 	"cosmossdk.io/x/upgrade"
 	"cosmossdk.io/x/upgrade/keeper"
 	"cosmossdk.io/x/upgrade/types"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/runtime"

--- a/x/upgrade/autocli.go
+++ b/x/upgrade/autocli.go
@@ -2,7 +2,6 @@ package upgrade
 
 import (
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
-
 	upgradev1beta1 "cosmossdk.io/x/upgrade/types"
 )
 

--- a/x/upgrade/client/cli/parse_test.go
+++ b/x/upgrade/client/cli/parse_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/x/upgrade/types"
+
 	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 )
 

--- a/x/upgrade/client/cli/tx.go
+++ b/x/upgrade/client/cli/tx.go
@@ -8,9 +8,9 @@ import (
 	"github.com/spf13/cobra"
 
 	addresscodec "cosmossdk.io/core/address"
-
 	"cosmossdk.io/x/upgrade/plan"
 	"cosmossdk.io/x/upgrade/types"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"

--- a/x/upgrade/keeper/grpc_query.go
+++ b/x/upgrade/keeper/grpc_query.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 
 	errorsmod "cosmossdk.io/errors"
-
 	"cosmossdk.io/x/upgrade/types"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/upgrade/keeper/grpc_query_test.go
+++ b/x/upgrade/keeper/grpc_query_test.go
@@ -9,10 +9,10 @@ import (
 
 	"cosmossdk.io/core/header"
 	storetypes "cosmossdk.io/store/types"
-
 	"cosmossdk.io/x/upgrade"
 	"cosmossdk.io/x/upgrade/keeper"
 	"cosmossdk.io/x/upgrade/types"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/testutil"

--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -18,9 +18,9 @@ import (
 	"cosmossdk.io/log"
 	"cosmossdk.io/store/prefix"
 	storetypes "cosmossdk.io/store/types"
-
 	xp "cosmossdk.io/x/upgrade/exported"
 	"cosmossdk.io/x/upgrade/types"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/telemetry"

--- a/x/upgrade/keeper/keeper_test.go
+++ b/x/upgrade/keeper/keeper_test.go
@@ -12,10 +12,10 @@ import (
 	"cosmossdk.io/core/header"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
-
 	"cosmossdk.io/x/upgrade"
 	"cosmossdk.io/x/upgrade/keeper"
 	"cosmossdk.io/x/upgrade/types"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/testutil"

--- a/x/upgrade/keeper/migrations.go
+++ b/x/upgrade/keeper/migrations.go
@@ -6,8 +6,8 @@ import (
 
 	storetypes "cosmossdk.io/core/store"
 	"cosmossdk.io/store/prefix"
-
 	"cosmossdk.io/x/upgrade/types"
+
 	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/x/upgrade/keeper/migrations_test.go
+++ b/x/upgrade/keeper/migrations_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	storetypes "cosmossdk.io/store/types"
-
 	"cosmossdk.io/x/upgrade/types"
+
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/testutil"
 )

--- a/x/upgrade/keeper/msg_server.go
+++ b/x/upgrade/keeper/msg_server.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"cosmossdk.io/errors"
-
 	"cosmossdk.io/x/upgrade/types"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/upgrade/keeper/msg_server_test.go
+++ b/x/upgrade/keeper/msg_server_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"cosmossdk.io/x/upgrade/types"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/address"
 )

--- a/x/upgrade/module.go
+++ b/x/upgrade/module.go
@@ -15,11 +15,11 @@ import (
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/depinject/appconfig"
-
 	"cosmossdk.io/x/upgrade/client/cli"
 	"cosmossdk.io/x/upgrade/keeper"
 	"cosmossdk.io/x/upgrade/types"
 	modulev1 "cosmossdk.io/x/upgrade/types/module"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"

--- a/x/upgrade/types/plan_test.go
+++ b/x/upgrade/types/plan_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/x/upgrade/types"
+
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 )
 

--- a/x/upgrade/types/proposal_test.go
+++ b/x/upgrade/types/proposal_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/x/upgrade/types"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	gov "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"


### PR DESCRIPTION
- Handle errors for burn deposits (https://github.com/atomone-hub/cosmos-sdk/pull/31/files#diff-84432fb495de7d21f9244eb6cbcfe39fc23d2e9c2ed9020a21974216dc4c5cb8R236-R239)

```
		if burnDeposits {
			err = keeper.DeleteAndBurnDeposits(ctx, proposal.Id)
		} else {
			err = keeper.RefundAndDeleteDeposits(ctx, proposal.Id)
		}
```

- Run `make lint-fix`
- Manually fix some code lint issues.
