### PR TITLE
refactor(x/gov): use interface checks instead of type checks

### DIFF
--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -282,7 +282,6 @@ func (keeper Keeper) ProposalKinds(p v1.Proposal) v1.ProposalKinds {
 	for _, msg := range p.Messages {
 		var sdkMsg sdk.Msg
 		if err := keeper.cdc.UnpackAny(msg, &sdkMsg); err == nil {
-
 			switch sdkMsg.(type) {
 			case interface {
 				IsProposalKindConstitutionAmendment()

--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -282,10 +282,15 @@ func (keeper Keeper) ProposalKinds(p v1.Proposal) v1.ProposalKinds {
 	for _, msg := range p.Messages {
 		var sdkMsg sdk.Msg
 		if err := keeper.cdc.UnpackAny(msg, &sdkMsg); err == nil {
+
 			switch sdkMsg.(type) {
-			case *v1.MsgProposeConstitutionAmendment:
+			case interface {
+				IsProposalKindConstitutionAmendment()
+			}:
 				kinds |= v1.ProposalKindConstitutionAmendment
-			case *v1.MsgProposeLaw:
+			case interface {
+				IsProposalKindLaw()
+			}:
 				kinds |= v1.ProposalKindLaw
 			default:
 				kinds |= v1.ProposalKindAny

--- a/x/gov/types/v1/msgs.go
+++ b/x/gov/types/v1/msgs.go
@@ -126,3 +126,7 @@ func (msg MsgProposeConstitutionAmendment) ValidateBasic() error {
 
 	return nil
 }
+
+func (msg MsgProposeConstitutionAmendment) IsProposalKindConstitutionAmendment() {}
+
+func (msg MsgProposeLaw) IsProposalKindLaw() {}


### PR DESCRIPTION
# Description

Helps https://github.com/atomone-hub/atomone/pull/248

This effectively loosen the checks, as any message implementing this interface will get this proposal kind.
This is on us to verify that none of our dependency adds a message with this flags (a non malicious dependency would have no reason to do that). I think the risk is acceptable. It makes the code on the https://github.com/atomone-hub/atomone/pull/248 PR nicer (no need again another extra wrapper)
