### PR TITLE
fix(x/group): the group module storeKey must have a value

### DIFF
--- a/x/group/placeholder.go
+++ b/x/group/placeholder.go
@@ -1,6 +1,9 @@
 package group
 
 var (
-	ModuleName string
-	StoreKey   string
+	// ModuleName is the module name constant used in many places
+	ModuleName = "group"
+
+	// StoreKey defines the primary module store key
+	StoreKey = ModuleName
 )


### PR DESCRIPTION
Or else some function like NewStore with that key fails because it
detects keys with the same prefix.

Indeed, surprisingly strings.HasPrefix("myKey", "") returns true.
