### PR TITLE
fix(x/genutil): simplify staking interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [#38](https://github.com/atomone-hub/cosmos-sdk/pull/38) Remove proposer reward params from `x/distribution` (base_proposer_reward and bonus_proposer_reward)
 * [#22](https://github.com/atomone-hub/cosmos-sdk/pull/22), [#25](https://github.com/atomone-hub/cosmos-sdk/pull/25) Remove non forked go modules from repository.
 * [#51](https://github.com/atomone-hub/cosmos-sdk/pull/51) Use gomock from `go.uber.org/mock/gomock` instead `github.com/golang/mock/gomock`.
+* [#52](https://github.com/atomone-hub/cosmos-sdk/pull/52) Simplify `genutil.StakingKeeper` interface.
 
 ### Bug Fixes
 

--- a/x/genutil/testutil/expected_keepers_mocks.go
+++ b/x/genutil/testutil/expected_keepers_mocks.go
@@ -18,7 +18,6 @@ import (
 	codec "github.com/cosmos/cosmos-sdk/codec"
 	types0 "github.com/cosmos/cosmos-sdk/types"
 	exported "github.com/cosmos/cosmos-sdk/x/bank/exported"
-	types1 "github.com/cosmos/cosmos-sdk/x/staking/types"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -59,21 +58,6 @@ func (m *MockStakingKeeper) ApplyAndReturnValidatorSetUpdates(arg0 context.Conte
 func (mr *MockStakingKeeperMockRecorder) ApplyAndReturnValidatorSetUpdates(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyAndReturnValidatorSetUpdates", reflect.TypeOf((*MockStakingKeeper)(nil).ApplyAndReturnValidatorSetUpdates), arg0)
-}
-
-// GetBondedValidatorsByPower mocks base method.
-func (m *MockStakingKeeper) GetBondedValidatorsByPower(arg0 context.Context) ([]types1.Validator, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBondedValidatorsByPower", arg0)
-	ret0, _ := ret[0].([]types1.Validator)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBondedValidatorsByPower indicates an expected call of GetBondedValidatorsByPower.
-func (mr *MockStakingKeeperMockRecorder) GetBondedValidatorsByPower(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBondedValidatorsByPower", reflect.TypeOf((*MockStakingKeeper)(nil).GetBondedValidatorsByPower), arg0)
 }
 
 // MockAccountKeeper is a mock of AccountKeeper interface.

--- a/x/genutil/types/expected_keepers.go
+++ b/x/genutil/types/expected_keepers.go
@@ -9,13 +9,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bankexported "github.com/cosmos/cosmos-sdk/x/bank/exported"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 // StakingKeeper defines the expected staking keeper (noalias)
 type StakingKeeper interface {
 	ApplyAndReturnValidatorSetUpdates(context.Context) ([]abci.ValidatorUpdate, error)
-	GetBondedValidatorsByPower(context.Context) ([]stakingtypes.Validator, error)
 }
 
 // AccountKeeper defines the expected account keeper (noalias)


### PR DESCRIPTION
the genutil.StakingKeeper interface is used in interchain-security and
the recent add of GetBondedValidatorByPower method breaks the
compilation. It appears that this add is not really needed so this
change removes it.

cc @Pantani 
