### PR TITLE
chore(gov): add sensible max value to `QuorumCheckCount` param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [#22](https://github.com/atomone-hub/cosmos-sdk/pull/22), [#25](https://github.com/atomone-hub/cosmos-sdk/pull/25) Remove non forked go modules from repository.
 * [#51](https://github.com/atomone-hub/cosmos-sdk/pull/51) Use gomock from `go.uber.org/mock/gomock` instead `github.com/golang/mock/gomock`.
 * [#52](https://github.com/atomone-hub/cosmos-sdk/pull/52) Simplify `genutil.StakingKeeper` interface.
+* [55](https://github.com/atomone-hub/cosmos-sdk/pull/55) Add sensible max to `QuorumCheckCount` param in `x/gov` module.
 
 ### Bug Fixes
 

--- a/x/gov/types/v1/genesis_test.go
+++ b/x/gov/types/v1/genesis_test.go
@@ -243,6 +243,15 @@ func TestValidateGenesis(t *testing.T) {
 			expErrMsg: "max voting period extension -1ns must be greater than or equal to the difference between the voting period 504h0m0s and the quorum timeout 480h0m0s",
 		},
 		{
+			name: "quorum check count is greater than max allowed",
+			genesisState: func() *v1.GenesisState {
+				params := v1.DefaultParams()
+				params.QuorumCheckCount = v1.MaxQuorumCheckCount + 1
+				return v1.NewGenesisState(v1.DefaultStartingProposalID, v1.DefaultParticipationEma, v1.DefaultParticipationEma, v1.DefaultParticipationEma, params)
+			},
+			expErrMsg: "quorum check count 1001 is too large, allowed max is 1000",
+		},
+		{
 			name: "invalid max deposit period",
 			genesisState: func() *v1.GenesisState {
 				params := v1.DefaultParams()

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -25,6 +25,10 @@ const (
 	// DefaultGovernorStatusChangePeriod is the default period that has to pass
 	// before a governor can change their status (e.g. from active to inactive).
 	DefaultGovernorStatusChangePeriod time.Duration = time.Hour * 24 * 28 // 28 days
+
+	// Provide a sensible upper limit to quorum check count to avoid excessive
+	// resource consumption.
+	MaxQuorumCheckCount = 1000
 )
 
 // MinVotingPeriod is set in stone by the constitution at 21 days, but it can
@@ -361,6 +365,11 @@ func (p Params) ValidateBasic() error {
 		}
 		if p.MaxVotingPeriodExtension.Nanoseconds() < p.VotingPeriod.Nanoseconds()-p.QuorumTimeout.Nanoseconds() {
 			return fmt.Errorf("max voting period extension %s must be greater than or equal to the difference between the voting period %s and the quorum timeout %s", p.MaxVotingPeriodExtension, p.VotingPeriod, p.QuorumTimeout)
+		}
+
+		// avoid a quorum check count that is too large
+		if p.QuorumCheckCount > MaxQuorumCheckCount {
+			return fmt.Errorf("quorum check count %d is too large, allowed max is %d", p.QuorumCheckCount, MaxQuorumCheckCount)
 		}
 	}
 


### PR DESCRIPTION
Add a constant `MaxQuorumCheckCount` set to 1000 (already too high, but a lower value might be too restrictive) to check against when doing param validation for `QuorumCheckCount`. This is to avoid excessive resource consumption by triggering too frequent quorum checks, but also to avoid a (extremely - really extremely - unlikely but still technically possible) division by zero issue.