### PR TITLE
fix(gov): reject out-of-order hunks and invalid control characters in insertion lines for unified diff constitution patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * (x/gov) [#35](https://github.com/atomone-hub/cosmos-sdk/pull/35) Cherry-pick [proposal v1 to v1beta1 converter fix from AtomOne](https://github.com/atomone-hub/atomone/pull/102)
+* (x/gov) [#56](https://github.com/atomone-hub/cosmos-sdk/pull/56) Fix unified diff parser to reject out-of-order hunks and invalid control characters in insertion lines.
 
 ## [Unreleased]
 

--- a/x/gov/types/unified_diff.go
+++ b/x/gov/types/unified_diff.go
@@ -209,6 +209,11 @@ func applyHunks(srcStr string, hunks []Hunk) ([]string, error) {
 			return nil, fmt.Errorf("hunk starts at line %d but source only has %d lines", hunk.SrcLine+1, len(srcLines))
 		}
 
+		// Reject out-of-order hunks
+		if hunk.SrcLine < srcIndex {
+			return nil, fmt.Errorf("hunk out of order: targets line %d but already processed up to line %d", hunk.SrcLine+1, srcIndex)
+		}
+
 		// Add unchanged lines before the hunk
 		for srcIndex < hunk.SrcLine {
 			if srcIndex >= len(srcLines) {
@@ -247,7 +252,10 @@ func applyHunks(srcStr string, hunks []Hunk) ([]string, error) {
 				}
 				srcIndex++
 			case '+':
-				// Insertion, add to result
+				// Insertion, add to result (if valid)
+				if err := validateLineContent(content); err != nil {
+					return nil, fmt.Errorf("invalid content in insertion line: %v", err)
+				}
 				result = append(result, content)
 			default:
 				return nil, fmt.Errorf("invalid diff line: %s", line)
@@ -280,4 +288,14 @@ func ApplyUnifiedDiff(src, diffStr string) (string, error) {
 	}
 
 	return strings.Join(resultLines, "\n"), nil
+}
+
+func validateLineContent(line string) error {
+	for i, r := range line {
+		// Reject control characters except horizontal tab
+		if (r < 32 && r != '\t') || r == 0x7F {
+			return fmt.Errorf("invalid control character 0x%02x at position %d", r, i)
+		}
+	}
+	return nil
 }

--- a/x/gov/types/unified_diff_test.go
+++ b/x/gov/types/unified_diff_test.go
@@ -196,6 +196,24 @@ func TestApplyUnifiedDiff(t *testing.T) {
 `,
 			wantErr: true,
 		},
+		{
+			name: "Out of order hunks",
+			src:  "Line one\nLine two\nLine three",
+			diffStr: `@@ -2,1 +2,1 @@
+-Line two
++Line two modified
+@@ -1,1 +1,1 @@
+-Line one
++Line one modified
+`,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid insertion content",
+			src:     "Line one\nLine two",
+			diffStr: "@@ -1,2 +1,3 @@\n Line one\n Line two\n+Line three with invalid char \b\n",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
As per the title of the PR.

Minor issues in the unified diff patch system for constitution amendments, both identified as part of the bounty program.
Issuing fix even though there is no urgency nor we consider the impact of the addressed issues of any severity.
It's still nice though to improve the code whenever possible