### PR TITLE
fix(gov): check error when traversing `QuorumCheckQueue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/gov) [#35](https://github.com/atomone-hub/cosmos-sdk/pull/35) Cherry-pick [proposal v1 to v1beta1 converter fix from AtomOne](https://github.com/atomone-hub/atomone/pull/102)
 * (x/gov) [#54](https://github.com/atomone-hub/cosmos-sdk/pull/54) Properly update min deposit and min initial deposit.
 * (x/gov) [#56](https://github.com/atomone-hub/cosmos-sdk/pull/56) Fix unified diff parser to reject out-of-order hunks and invalid control characters in insertion lines.
+* (x/gov) [#58](https://github.com/atomone-hub/cosmos-sdk/pull/58) Check errors in endblocker when traversing the quorum check queue.
 
 ## [Unreleased]
 

--- a/x/gov/abci.go
+++ b/x/gov/abci.go
@@ -105,7 +105,7 @@ func EndBlocker(ctx sdk.Context, keeper *keeper.Keeper) error {
 
 	// fetch proposals that are due to be checked for quorum
 	rng = collections.NewPrefixUntilPairRange[time.Time, uint64](ctx.BlockTime())
-	keeper.QuorumCheckQueue.Walk(ctx, rng, func(key collections.Pair[time.Time, uint64], quorumCheckEntry v1.QuorumCheckQueueEntry) (bool, error) {
+	err = keeper.QuorumCheckQueue.Walk(ctx, rng, func(key collections.Pair[time.Time, uint64], quorumCheckEntry v1.QuorumCheckQueueEntry) (bool, error) {
 		// remove from queue
 		keeper.QuorumCheckQueue.Remove(ctx, key)
 
@@ -196,6 +196,9 @@ func EndBlocker(ctx sdk.Context, keeper *keeper.Keeper) error {
 
 		return false, nil
 	})
+	if err != nil {
+		return err
+	}
 
 	// fetch active proposals whose voting periods have ended (are passed the block time)
 	rng = collections.NewPrefixUntilPairRange[time.Time, uint64](ctx.BlockTime())


### PR DESCRIPTION
In the endblocker when going over proposals in the `QuorumCheckQueue` there is no check for errors. This PR adds the missing error check