### PR TITLE
fix(x/distribution): Nakamoto coefficient update change

### DIFF
--- a/x/distribution/keeper/nakamoto_bonus.go
+++ b/x/distribution/keeper/nakamoto_bonus.go
@@ -54,7 +54,7 @@ func (k Keeper) AdjustNakamotoBonusCoefficient(ctx sdk.Context) error {
 	// split into 3 groups as evenly as possible: high, medium, low
 	groupSize := n / 3
 	high := validators[:groupSize]
-	low := validators[groupSize*2:]
+	low := validators[n-groupSize:]
 
 	sum := func(vals []stakingtypes.Validator) math.Int {
 		total := math.ZeroInt()

--- a/x/distribution/keeper/nakamoto_bonus_test.go
+++ b/x/distribution/keeper/nakamoto_bonus_test.go
@@ -152,6 +152,24 @@ func TestAdjustEta_ClampOne(t *testing.T) {
 	require.Equal(t, types.DefaultNakamotoBonusMaximumCoefficient, nakamotoBonusCoefficient)
 }
 
+func TestAdjustEta_EvenGroupSplitNonDivisibleBy3(t *testing.T) {
+	initialEta := math.LegacyNewDecWithPrec(5, 2) // 0.05
+	s := setupTestKeeper(t, initialEta, 100)
+
+	// 5 validators (not divisible by 3): groupSize = 5/3 = 1
+	// Sorted descending: [300, 200, 200, 200, 100]
+	// high = [300], low = [100], highAvg/lowAvg = 3 >= 3 → should increase
+	createValidators(s.ctx, s.stakingKeeper, 300, 200, 200, 200, 100)
+
+	require.NoError(t, s.distrKeeper.AdjustNakamotoBonusCoefficient(s.ctx))
+
+	nakamotoBonusCoefficient, err := s.distrKeeper.GetNakamotoBonusCoefficient(s.ctx)
+	require.NoError(t, err)
+	expectedEta := initialEta.Add(types.DefaultNakamotoBonusStep)
+	require.Equal(t, expectedEta, nakamotoBonusCoefficient,
+		"η should increase when high/low ratio >= 3 with even group sizes")
+}
+
 func TestAllocateTokensWithNakamotoBonusImbalancedValidators(t *testing.T) {
 	// Realistic scenario: top 5 validators have 70% of stake
 	s := setupTestKeeper(t, math.LegacyNewDecWithPrec(5, 2), 100) // η = 0.05

--- a/x/gov/migrations/v5/store_test.go
+++ b/x/gov/migrations/v5/store_test.go
@@ -97,7 +97,7 @@ func legacyV4Params() v1.Params {
 		Quorum:                         "0.334000000000000000",
 		Threshold:                      v1.DefaultThreshold.String(),
 		MinInitialDepositRatio:         "0.100000000000000000",
-		BurnVoteQuorum:                 v1.DefaultBurnVoteQuorom,
+		BurnVoteQuorum:                 v1.DefaultBurnVoteQuorum,
 		BurnProposalDepositPrevote:     v1.DefaultBurnProposalPrevote,
 		ConstitutionAmendmentQuorum:    v1.DefaultMinConstitutionAmendmentQuorum.String(),
 		ConstitutionAmendmentThreshold: v1.DefaultConstitutionAmendmentThreshold.String(),


### PR DESCRIPTION
V4 Audit, issue 22

The size of the high group and low group could differ if the total number of bonded validators is not evenly divisible by 3.

Without this change the lowest group of validators might have an additional validator with respect to the highest group of validators. This would slightly increase the low group VP average and slightly bias the Nakamoto bonus coefficient towards lower numbers.
