### PR TITLE
fix(x/gov): prevent governance re-delegation right after creating a new governance delegation.

### DIFF
--- a/x/gov/keeper/msg_server.go
+++ b/x/gov/keeper/msg_server.go
@@ -483,8 +483,13 @@ func (k msgServer) UpdateGovernorStatus(goCtx context.Context, msg *v1.MsgUpdate
 	governor.LastStatusChangeTime = &changeTime
 	// prevent a change to active if min self-delegation is not met
 	if governor.IsActive() {
-		if !k.ValidateGovernorMinSelfDelegation(ctx, governor) {
-			return nil, govtypes.ErrInsufficientGovernorDelegation.Wrap("cannot set status to active: minimum self-delegation not met")
+		minSelfDelegation, _ := math.NewIntFromString(params.MinGovernorSelfDelegation)
+		bondedTokens, err := k.getGovernorBondedTokens(ctx, govAddr)
+		if err != nil {
+			return nil, err
+		}
+		if bondedTokens.LT(minSelfDelegation) {
+			return nil, govtypes.ErrInsufficientGovernorDelegation.Wrapf("minimum self-delegation required: %s, total bonded tokens: %s", minSelfDelegation, bondedTokens)
 		}
 	}
 
@@ -505,8 +510,7 @@ func (k msgServer) UpdateGovernorStatus(goCtx context.Context, msg *v1.MsgUpdate
 			if err != nil {
 				return nil, err
 			}
-		}
-		if delegation.GovernorAddress != govAddr.String() {
+		} else if delegation.GovernorAddress != govAddr.String() {
 			err := k.RedelegateToGovernor(ctx, addr, govAddr)
 			if err != nil {
 				return nil, err

--- a/x/gov/keeper/msg_server_test.go
+++ b/x/gov/keeper/msg_server_test.go
@@ -4,14 +4,19 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/mock/gomock"
+
 	sdkmath "cosmossdk.io/math"
 
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 const (
@@ -1737,4 +1742,119 @@ func (suite *KeeperTestSuite) TestSubmitProposal_InitialDeposit() {
 			suite.Require().NoError(err)
 		})
 	}
+}
+
+func (suite *KeeperTestSuite) TestUpdateGovernorStatus_NoDelegation_CallsDelegateToGovernor() {
+	// Create a fresh address for the governor
+	addrs := simtestutil.CreateRandomAccounts(1)
+	addr := addrs[0]
+	govAddr := govtypes.GovernorAddress(addr.Bytes())
+
+	// Create a validator address and mock staking delegations so that
+	// getGovernorBondedTokens returns enough to satisfy MinGovernorSelfDelegation
+	valAddr := sdk.ValAddress(addr)
+	bondedTokens := sdkmath.NewInt(2000_000000)
+	delegatorShares := sdkmath.LegacyNewDecFromInt(bondedTokens)
+
+	// Set up the keeper with only the staking mocks needed by UpdateGovernorStatus:
+	// - IterateDelegations: called by getGovernorBondedTokens and DelegateToGovernor
+	// - GetValidator: called inside IterateDelegations callback in getGovernorBondedTokens
+	govKeeper, _, _, _, _, _, ctx := setupGovKeeper(suite.T(), func(ctx sdk.Context, m mocks) {
+		mockAccountKeeperExpectations(ctx, m)
+
+		m.stakingKeeper.EXPECT().IterateDelegations(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx sdk.Context, delegator sdk.AccAddress, fn func(int64, stakingtypes.DelegationI) bool) error {
+				if delegator.Equals(addr) {
+					fn(0, stakingtypes.Delegation{
+						DelegatorAddress: delegator.String(),
+						ValidatorAddress: valAddr.String(),
+						Shares:           delegatorShares,
+					})
+				}
+				return nil
+			},
+		).AnyTimes()
+		m.stakingKeeper.EXPECT().GetValidator(gomock.Any(), gomock.Any()).Return(stakingtypes.Validator{
+			Tokens:          bondedTokens,
+			DelegatorShares: delegatorShares,
+			Status:          stakingtypes.Bonded,
+		}, nil).AnyTimes()
+	})
+	msgSrvr := keeper.NewMsgServerImpl(govKeeper)
+
+	// Create an inactive governor with a status change time far enough in the past
+	// to satisfy the GovernorStatusChangePeriod (default 28 days)
+	pastTime := time.Now().Add(-30 * 24 * time.Hour)
+	governor, err := v1.NewGovernor(govAddr.String(), v1.GovernorDescription{}, pastTime)
+	suite.Require().NoError(err)
+	governor.Status = v1.Inactive
+	governor.LastStatusChangeTime = &pastTime
+	err = govKeeper.Governors.Set(ctx, governor.GetAddress(), governor)
+	suite.Require().NoError(err)
+
+	// Verify no governance delegation exists for this address
+	_, err = govKeeper.GovernanceDelegations.Get(ctx, addr)
+	suite.Require().Error(err)
+
+	// Call UpdateGovernorStatus to transition to Active
+	msg := v1.NewMsgUpdateGovernorStatus(addr, v1.Active)
+	_, err = msgSrvr.UpdateGovernorStatus(ctx, msg)
+	suite.Require().NoError(err)
+
+	// Verify governance delegation was created (DelegateToGovernor was called)
+	delegation, err := govKeeper.GovernanceDelegations.Get(ctx, addr)
+	suite.Require().NoError(err)
+	suite.Require().Equal(govAddr.String(), delegation.GovernorAddress)
+}
+
+func (suite *KeeperTestSuite) TestUpdateGovernorStatus_InsufficientDelegation_Fails() {
+	// Create a fresh address for the governor
+	addrs := simtestutil.CreateRandomAccounts(1)
+	addr := addrs[0]
+	govAddr := govtypes.GovernorAddress(addr.Bytes())
+
+	// Create a validator address with bonded tokens below the default
+	// MinGovernorSelfDelegation (1000_000000)
+	valAddr := sdk.ValAddress(addr)
+	bondedTokens := sdkmath.NewInt(500_000000)
+	delegatorShares := sdkmath.LegacyNewDecFromInt(bondedTokens)
+
+	// Set up the keeper with only the staking mocks needed by UpdateGovernorStatus
+	govKeeper, _, _, _, _, _, ctx := setupGovKeeper(suite.T(), func(ctx sdk.Context, m mocks) {
+		mockAccountKeeperExpectations(ctx, m)
+
+		m.stakingKeeper.EXPECT().IterateDelegations(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx sdk.Context, delegator sdk.AccAddress, fn func(int64, stakingtypes.DelegationI) bool) error {
+				if delegator.Equals(addr) {
+					fn(0, stakingtypes.Delegation{
+						DelegatorAddress: delegator.String(),
+						ValidatorAddress: valAddr.String(),
+						Shares:           delegatorShares,
+					})
+				}
+				return nil
+			},
+		).AnyTimes()
+		m.stakingKeeper.EXPECT().GetValidator(gomock.Any(), gomock.Any()).Return(stakingtypes.Validator{
+			Tokens:          bondedTokens,
+			DelegatorShares: delegatorShares,
+			Status:          stakingtypes.Bonded,
+		}, nil).AnyTimes()
+	})
+	msgSrvr := keeper.NewMsgServerImpl(govKeeper)
+
+	// Create an inactive governor with a status change time far enough in the past
+	pastTime := time.Now().Add(-30 * 24 * time.Hour)
+	governor, err := v1.NewGovernor(govAddr.String(), v1.GovernorDescription{}, pastTime)
+	suite.Require().NoError(err)
+	governor.Status = v1.Inactive
+	governor.LastStatusChangeTime = &pastTime
+	err = govKeeper.Governors.Set(ctx, governor.GetAddress(), governor)
+	suite.Require().NoError(err)
+
+	// Call UpdateGovernorStatus to transition to Active — should fail
+	msg := v1.NewMsgUpdateGovernorStatus(addr, v1.Active)
+	_, err = msgSrvr.UpdateGovernorStatus(ctx, msg)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, govtypes.ErrInsufficientGovernorDelegation)
 }

--- a/x/gov/keeper/msg_server_test.go
+++ b/x/gov/keeper/msg_server_test.go
@@ -5,19 +5,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"cosmossdk.io/collections"
 	sdkmath "cosmossdk.io/math"
-
-	"github.com/stretchr/testify/require"
 
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/keeper"
-	"github.com/cosmos/cosmos-sdk/x/gov/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
@@ -1818,8 +1816,8 @@ func TestUpdateGovernorStatus(t *testing.T) {
 			// Assert governor shares
 			var shares []v1.GovernorValShares
 			err = govKeeper.ValidatorSharesByGovernor.Walk(ctx,
-				collections.NewPrefixedPairRange[types.GovernorAddress, sdk.ValAddress](govAddr),
-				func(_ collections.Pair[types.GovernorAddress, sdk.ValAddress], s v1.GovernorValShares) (stop bool, err error) {
+				collections.NewPrefixedPairRange[govtypes.GovernorAddress, sdk.ValAddress](govAddr),
+				func(_ collections.Pair[govtypes.GovernorAddress, sdk.ValAddress], s v1.GovernorValShares) (stop bool, err error) {
 					shares = append(shares, s)
 					return false, nil
 				})

--- a/x/gov/keeper/msg_server_test.go
+++ b/x/gov/keeper/msg_server_test.go
@@ -2,17 +2,22 @@ package keeper_test
 
 import (
 	"strings"
+	"testing"
 	"time"
 
 	"go.uber.org/mock/gomock"
 
+	"cosmossdk.io/collections"
 	sdkmath "cosmossdk.io/math"
+
+	"github.com/stretchr/testify/require"
 
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	"github.com/cosmos/cosmos-sdk/x/gov/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
@@ -1744,117 +1749,83 @@ func (suite *KeeperTestSuite) TestSubmitProposal_InitialDeposit() {
 	}
 }
 
-func (suite *KeeperTestSuite) TestUpdateGovernorStatus_NoDelegation_CallsDelegateToGovernor() {
-	// Create a fresh address for the governor
-	addrs := simtestutil.CreateRandomAccounts(1)
-	addr := addrs[0]
-	govAddr := govtypes.GovernorAddress(addr.Bytes())
+func TestUpdateGovernorStatus(t *testing.T) {
+	tests := []struct {
+		name         string
+		bondedTokens sdkmath.Int
+		expectErr    error
+	}{
+		{
+			name:         "sufficient delegation creates governance delegation",
+			bondedTokens: sdkmath.NewInt(2000_000000),
+		},
+		{
+			name:         "insufficient delegation fails",
+			bondedTokens: sdkmath.NewInt(500_000000),
+			expectErr:    govtypes.ErrInsufficientGovernorDelegation,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				addr            = simtestutil.CreateRandomAccounts(1)[0]
+				govAddr         = govtypes.GovernorAddress(addr.Bytes())
+				valAddr         = sdk.ValAddress(addr)
+				delegatorShares = sdkmath.LegacyNewDecFromInt(tc.bondedTokens)
+			)
+			govKeeper, _, _, _, _, _, ctx := setupGovKeeper(t, func(ctx sdk.Context, m mocks) {
+				mockAccountKeeperExpectations(ctx, m)
+				m.stakingKeeper.EXPECT().IterateDelegations(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx sdk.Context, delegator sdk.AccAddress, fn func(int64, stakingtypes.DelegationI) bool) error {
+						if delegator.Equals(addr) {
+							fn(0, stakingtypes.Delegation{
+								DelegatorAddress: delegator.String(),
+								ValidatorAddress: valAddr.String(),
+								Shares:           delegatorShares,
+							})
+						}
+						return nil
+					},
+				).AnyTimes()
+				m.stakingKeeper.EXPECT().GetValidator(gomock.Any(), gomock.Any()).Return(stakingtypes.Validator{
+					Tokens:          tc.bondedTokens,
+					DelegatorShares: delegatorShares,
+					Status:          stakingtypes.Bonded,
+				}, nil).AnyTimes()
+			})
+			msgSrvr := keeper.NewMsgServerImpl(govKeeper)
+			// Create an inactive governor with a status change time far enough in the past
+			// to satisfy the GovernorStatusChangePeriod (default 28 days)
+			pastTime := time.Now().Add(-30 * 24 * time.Hour)
+			governor, err := v1.NewGovernor(govAddr.String(), v1.GovernorDescription{}, pastTime)
+			require.NoError(t, err)
+			governor.Status = v1.Inactive
+			governor.LastStatusChangeTime = &pastTime
+			err = govKeeper.Governors.Set(ctx, governor.GetAddress(), governor)
+			require.NoError(t, err)
 
-	// Create a validator address and mock staking delegations so that
-	// getGovernorBondedTokens returns enough to satisfy MinGovernorSelfDelegation
-	valAddr := sdk.ValAddress(addr)
-	bondedTokens := sdkmath.NewInt(2000_000000)
-	delegatorShares := sdkmath.LegacyNewDecFromInt(bondedTokens)
+			_, err = msgSrvr.UpdateGovernorStatus(ctx, v1.NewMsgUpdateGovernorStatus(addr, v1.Active))
 
-	// Set up the keeper with only the staking mocks needed by UpdateGovernorStatus:
-	// - IterateDelegations: called by getGovernorBondedTokens and DelegateToGovernor
-	// - GetValidator: called inside IterateDelegations callback in getGovernorBondedTokens
-	govKeeper, _, _, _, _, _, ctx := setupGovKeeper(suite.T(), func(ctx sdk.Context, m mocks) {
-		mockAccountKeeperExpectations(ctx, m)
-
-		m.stakingKeeper.EXPECT().IterateDelegations(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx sdk.Context, delegator sdk.AccAddress, fn func(int64, stakingtypes.DelegationI) bool) error {
-				if delegator.Equals(addr) {
-					fn(0, stakingtypes.Delegation{
-						DelegatorAddress: delegator.String(),
-						ValidatorAddress: valAddr.String(),
-						Shares:           delegatorShares,
-					})
-				}
-				return nil
-			},
-		).AnyTimes()
-		m.stakingKeeper.EXPECT().GetValidator(gomock.Any(), gomock.Any()).Return(stakingtypes.Validator{
-			Tokens:          bondedTokens,
-			DelegatorShares: delegatorShares,
-			Status:          stakingtypes.Bonded,
-		}, nil).AnyTimes()
-	})
-	msgSrvr := keeper.NewMsgServerImpl(govKeeper)
-
-	// Create an inactive governor with a status change time far enough in the past
-	// to satisfy the GovernorStatusChangePeriod (default 28 days)
-	pastTime := time.Now().Add(-30 * 24 * time.Hour)
-	governor, err := v1.NewGovernor(govAddr.String(), v1.GovernorDescription{}, pastTime)
-	suite.Require().NoError(err)
-	governor.Status = v1.Inactive
-	governor.LastStatusChangeTime = &pastTime
-	err = govKeeper.Governors.Set(ctx, governor.GetAddress(), governor)
-	suite.Require().NoError(err)
-
-	// Verify no governance delegation exists for this address
-	_, err = govKeeper.GovernanceDelegations.Get(ctx, addr)
-	suite.Require().Error(err)
-
-	// Call UpdateGovernorStatus to transition to Active
-	msg := v1.NewMsgUpdateGovernorStatus(addr, v1.Active)
-	_, err = msgSrvr.UpdateGovernorStatus(ctx, msg)
-	suite.Require().NoError(err)
-
-	// Verify governance delegation was created (DelegateToGovernor was called)
-	delegation, err := govKeeper.GovernanceDelegations.Get(ctx, addr)
-	suite.Require().NoError(err)
-	suite.Require().Equal(govAddr.String(), delegation.GovernorAddress)
-}
-
-func (suite *KeeperTestSuite) TestUpdateGovernorStatus_InsufficientDelegation_Fails() {
-	// Create a fresh address for the governor
-	addrs := simtestutil.CreateRandomAccounts(1)
-	addr := addrs[0]
-	govAddr := govtypes.GovernorAddress(addr.Bytes())
-
-	// Create a validator address with bonded tokens below the default
-	// MinGovernorSelfDelegation (1000_000000)
-	valAddr := sdk.ValAddress(addr)
-	bondedTokens := sdkmath.NewInt(500_000000)
-	delegatorShares := sdkmath.LegacyNewDecFromInt(bondedTokens)
-
-	// Set up the keeper with only the staking mocks needed by UpdateGovernorStatus
-	govKeeper, _, _, _, _, _, ctx := setupGovKeeper(suite.T(), func(ctx sdk.Context, m mocks) {
-		mockAccountKeeperExpectations(ctx, m)
-
-		m.stakingKeeper.EXPECT().IterateDelegations(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx sdk.Context, delegator sdk.AccAddress, fn func(int64, stakingtypes.DelegationI) bool) error {
-				if delegator.Equals(addr) {
-					fn(0, stakingtypes.Delegation{
-						DelegatorAddress: delegator.String(),
-						ValidatorAddress: valAddr.String(),
-						Shares:           delegatorShares,
-					})
-				}
-				return nil
-			},
-		).AnyTimes()
-		m.stakingKeeper.EXPECT().GetValidator(gomock.Any(), gomock.Any()).Return(stakingtypes.Validator{
-			Tokens:          bondedTokens,
-			DelegatorShares: delegatorShares,
-			Status:          stakingtypes.Bonded,
-		}, nil).AnyTimes()
-	})
-	msgSrvr := keeper.NewMsgServerImpl(govKeeper)
-
-	// Create an inactive governor with a status change time far enough in the past
-	pastTime := time.Now().Add(-30 * 24 * time.Hour)
-	governor, err := v1.NewGovernor(govAddr.String(), v1.GovernorDescription{}, pastTime)
-	suite.Require().NoError(err)
-	governor.Status = v1.Inactive
-	governor.LastStatusChangeTime = &pastTime
-	err = govKeeper.Governors.Set(ctx, governor.GetAddress(), governor)
-	suite.Require().NoError(err)
-
-	// Call UpdateGovernorStatus to transition to Active — should fail
-	msg := v1.NewMsgUpdateGovernorStatus(addr, v1.Active)
-	_, err = msgSrvr.UpdateGovernorStatus(ctx, msg)
-	suite.Require().Error(err)
-	suite.Require().ErrorIs(err, govtypes.ErrInsufficientGovernorDelegation)
+			if tc.expectErr != nil {
+				require.ErrorIs(t, err, tc.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			// Assert self governance delegation
+			delegation, err := govKeeper.GovernanceDelegations.Get(ctx, addr)
+			require.NoError(t, err)
+			require.Equal(t, govAddr.String(), delegation.GovernorAddress)
+			// Assert governor shares
+			var shares []v1.GovernorValShares
+			err = govKeeper.ValidatorSharesByGovernor.Walk(ctx,
+				collections.NewPrefixedPairRange[types.GovernorAddress, sdk.ValAddress](govAddr),
+				func(_ collections.Pair[types.GovernorAddress, sdk.ValAddress], s v1.GovernorValShares) (stop bool, err error) {
+					shares = append(shares, s)
+					return false, nil
+				})
+			require.NoError(t, err)
+			require.Len(t, shares, 1)
+			require.Equal(t, delegatorShares.String(), shares[0].Shares.String())
+		})
+	}
 }

--- a/x/gov/keeper/msg_server_test.go
+++ b/x/gov/keeper/msg_server_test.go
@@ -1749,9 +1749,10 @@ func (suite *KeeperTestSuite) TestSubmitProposal_InitialDeposit() {
 
 func TestUpdateGovernorStatus(t *testing.T) {
 	tests := []struct {
-		name         string
-		bondedTokens sdkmath.Int
-		expectErr    error
+		name                    string
+		bondedTokens            sdkmath.Int
+		existingDelegationToOther bool
+		expectErr               error
 	}{
 		{
 			name:         "sufficient delegation creates governance delegation",
@@ -1762,12 +1763,20 @@ func TestUpdateGovernorStatus(t *testing.T) {
 			bondedTokens: sdkmath.NewInt(500_000000),
 			expectErr:    govtypes.ErrInsufficientGovernorDelegation,
 		},
+		{
+			name:                    "existing delegation to other governor triggers redelegation",
+			bondedTokens:            sdkmath.NewInt(2000_000000),
+			existingDelegationToOther: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var (
-				addr            = simtestutil.CreateRandomAccounts(1)[0]
+				accs            = simtestutil.CreateRandomAccounts(2)
+				addr            = accs[0]
+				otherAddr       = accs[1]
 				govAddr         = govtypes.GovernorAddress(addr.Bytes())
+				otherGovAddr    = govtypes.GovernorAddress(otherAddr.Bytes())
 				valAddr         = sdk.ValAddress(addr)
 				delegatorShares = sdkmath.LegacyNewDecFromInt(tc.bondedTokens)
 			)
@@ -1792,9 +1801,22 @@ func TestUpdateGovernorStatus(t *testing.T) {
 				}, nil).AnyTimes()
 			})
 			msgSrvr := keeper.NewMsgServerImpl(govKeeper)
+			pastTime := time.Now().Add(-30 * 24 * time.Hour)
+
+			if tc.existingDelegationToOther {
+				// Create an active governor that addr is currently delegating to
+				otherGovernor, err := v1.NewGovernor(otherGovAddr.String(), v1.GovernorDescription{}, pastTime)
+				require.NoError(t, err)
+				otherGovernor.Status = v1.Active
+				otherGovernor.LastStatusChangeTime = &pastTime
+				err = govKeeper.Governors.Set(ctx, otherGovernor.GetAddress(), otherGovernor)
+				require.NoError(t, err)
+				err = govKeeper.DelegateToGovernor(ctx, addr, otherGovAddr)
+				require.NoError(t, err)
+			}
+
 			// Create an inactive governor with a status change time far enough in the past
 			// to satisfy the GovernorStatusChangePeriod (default 28 days)
-			pastTime := time.Now().Add(-30 * 24 * time.Hour)
 			governor, err := v1.NewGovernor(govAddr.String(), v1.GovernorDescription{}, pastTime)
 			require.NoError(t, err)
 			governor.Status = v1.Inactive
@@ -1824,6 +1846,19 @@ func TestUpdateGovernorStatus(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, shares, 1)
 			require.Equal(t, delegatorShares.String(), shares[0].Shares.String())
+
+			if tc.existingDelegationToOther {
+				// Assert shares removed from the other governor
+				var otherShares []v1.GovernorValShares
+				err = govKeeper.ValidatorSharesByGovernor.Walk(ctx,
+					collections.NewPrefixedPairRange[govtypes.GovernorAddress, sdk.ValAddress](otherGovAddr),
+					func(_ collections.Pair[govtypes.GovernorAddress, sdk.ValAddress], s v1.GovernorValShares) (stop bool, err error) {
+						otherShares = append(otherShares, s)
+						return false, nil
+					})
+				require.NoError(t, err)
+				require.Empty(t, otherShares)
+			}
 		})
 	}
 }

--- a/x/gov/keeper/msg_server_test.go
+++ b/x/gov/keeper/msg_server_test.go
@@ -1749,10 +1749,10 @@ func (suite *KeeperTestSuite) TestSubmitProposal_InitialDeposit() {
 
 func TestUpdateGovernorStatus(t *testing.T) {
 	tests := []struct {
-		name                    string
-		bondedTokens            sdkmath.Int
+		name                      string
+		bondedTokens              sdkmath.Int
 		existingDelegationToOther bool
-		expectErr               error
+		expectErr                 error
 	}{
 		{
 			name:         "sufficient delegation creates governance delegation",
@@ -1764,8 +1764,8 @@ func TestUpdateGovernorStatus(t *testing.T) {
 			expectErr:    govtypes.ErrInsufficientGovernorDelegation,
 		},
 		{
-			name:                    "existing delegation to other governor triggers redelegation",
-			bondedTokens:            sdkmath.NewInt(2000_000000),
+			name:                      "existing delegation to other governor triggers redelegation",
+			bondedTokens:              sdkmath.NewInt(2000_000000),
 			existingDelegationToOther: true,
 		},
 	}


### PR DESCRIPTION
The creation of a governance self-delegation could never happen in `UpdateGovernorStatus`, a call to [ValidateGovernorMinSelfDelegation](https://github.com/atomone-hub/cosmos-sdk/blob/release/v0.50.x/x/gov/keeper/msg_server.go#L486) would generate a panic if the governor did not already have a minimum governance self delegation (see #64).

This PR addresses issue #64, and resolves an issue that could cause a governance re-delegation to happen right after the creation of a self governance delegation. 

Fixes A-19
Closes: #64 

