### PR TITLE
fix(x/gov): fixed inverted check in genesis import

### DIFF
--- a/x/gov/genesis.go
+++ b/x/gov/genesis.go
@@ -206,8 +206,11 @@ func InitGenesis(ctx sdk.Context, ak types.AccountKeeper, bk types.BankKeeper, k
 
 		// if account is active governor and delegation is not to self, error
 		delGovAddr := types.GovernorAddress(delAddr)
-		if _, err = k.Governors.Get(ctx, delGovAddr); err == nil && !delGovAddr.Equals(govAddr) {
-			panic(fmt.Sprintf("account %s is an active governor and cannot delegate", delAddr.String()))
+		gov, err := k.Governors.Get(ctx, delGovAddr)
+		if err == nil {
+			if gov.IsActive() && !delGovAddr.Equals(govAddr) {
+				panic(fmt.Sprintf("account %s is an active governor and cannot delegate", delAddr.String()))
+			}
 		}
 
 		err = k.DelegateToGovernor(ctx, delAddr, govAddr)

--- a/x/gov/genesis.go
+++ b/x/gov/genesis.go
@@ -206,7 +206,7 @@ func InitGenesis(ctx sdk.Context, ak types.AccountKeeper, bk types.BankKeeper, k
 
 		// if account is active governor and delegation is not to self, error
 		delGovAddr := types.GovernorAddress(delAddr)
-		if _, err = k.Governors.Get(ctx, delGovAddr); err != nil && !delGovAddr.Equals(govAddr) {
+		if _, err = k.Governors.Get(ctx, delGovAddr); err == nil && !delGovAddr.Equals(govAddr) {
 			panic(fmt.Sprintf("account %s is an active governor and cannot delegate", delAddr.String()))
 		}
 

--- a/x/gov/genesis_test.go
+++ b/x/gov/genesis_test.go
@@ -57,6 +57,95 @@ func TestImportExportQueues_ErrorUnconsistentState(t *testing.T) {
 	require.NotEmpty(t, genState.LastMinInitialDeposit.Value)
 }
 
+// TestInitGenesis_GovernorDelegationToOtherGovernorPanics verifies that an
+// active governor cannot delegate to a different governor.
+func TestInitGenesis_GovernorDelegationToOtherGovernorPanics(t *testing.T) {
+	suite := createTestSuite(t)
+	app := suite.App
+	ctx := app.BaseApp.NewContext(false)
+
+	// Create two governors
+	governor1PubKey := pubkeys[0]
+	governor2PubKey := pubkeys[1]
+
+	governor1AccAddr := sdk.AccAddress(governor1PubKey.Address())
+	governor2AccAddr := sdk.AccAddress(governor2PubKey.Address())
+
+	gov1Acc := suite.AccountKeeper.NewAccountWithAddress(ctx, governor1AccAddr)
+	suite.AccountKeeper.SetAccount(ctx, gov1Acc)
+
+	gov2Acc := suite.AccountKeeper.NewAccountWithAddress(ctx, governor2AccAddr)
+	suite.AccountKeeper.SetAccount(ctx, gov2Acc)
+
+	govAddr1 := types.GovernorAddress(governor1AccAddr)
+	govAddr2 := types.GovernorAddress(governor2AccAddr)
+	now := time.Now().UTC()
+
+	governor1, err := v1.NewGovernor(govAddr1.String(), v1.NewGovernorDescription("test-gov-1", "", "", "", ""), now)
+	require.NoError(t, err)
+	governor2, err := v1.NewGovernor(govAddr2.String(), v1.NewGovernorDescription("test-gov-2", "", "", "", ""), now)
+	require.NoError(t, err)
+
+	defaultState := v1.DefaultGenesisState()
+	defaultState.Governors = []*v1.Governor{&governor1, &governor2}
+	// Governor 1 attempts to delegate to Governor 2 — must panic
+	defaultState.GovernanceDelegations = []*v1.GovernanceDelegation{
+		{
+			DelegatorAddress: governor1AccAddr.String(),
+			GovernorAddress:  govAddr2.String(),
+		},
+	}
+
+	require.Panics(t, func() {
+		gov.InitGenesis(ctx, suite.AccountKeeper, suite.BankKeeper, suite.GovKeeper, defaultState)
+	})
+}
+
+// TestInitGenesis_InactiveGovernorDelegationToOtherGovernor verifies that an
+// inactive governor can delegate to a different governor.
+func TestInitGenesis_InactiveGovernorDelegationToOtherGovernor(t *testing.T) {
+	suite := createTestSuite(t)
+	app := suite.App
+	ctx := app.BaseApp.NewContext(false)
+
+	governor1PubKey := pubkeys[0]
+	governor2PubKey := pubkeys[1]
+
+	governor1AccAddr := sdk.AccAddress(governor1PubKey.Address())
+	governor2AccAddr := sdk.AccAddress(governor2PubKey.Address())
+
+	gov1Acc := suite.AccountKeeper.NewAccountWithAddress(ctx, governor1AccAddr)
+	suite.AccountKeeper.SetAccount(ctx, gov1Acc)
+
+	gov2Acc := suite.AccountKeeper.NewAccountWithAddress(ctx, governor2AccAddr)
+	suite.AccountKeeper.SetAccount(ctx, gov2Acc)
+
+	govAddr1 := types.GovernorAddress(governor1AccAddr)
+	govAddr2 := types.GovernorAddress(governor2AccAddr)
+	now := time.Now().UTC()
+
+	governor1, err := v1.NewGovernor(govAddr1.String(), v1.NewGovernorDescription("test-gov-1", "", "", "", ""), now)
+	require.NoError(t, err)
+	governor1.Status = v1.Inactive // make governor 1 inactive
+
+	governor2, err := v1.NewGovernor(govAddr2.String(), v1.NewGovernorDescription("test-gov-2", "", "", "", ""), now)
+	require.NoError(t, err)
+
+	defaultState := v1.DefaultGenesisState()
+	defaultState.Governors = []*v1.Governor{&governor1, &governor2}
+	// Inactive governor 1 delegates to active governor 2 — must not panic
+	defaultState.GovernanceDelegations = []*v1.GovernanceDelegation{
+		{
+			DelegatorAddress: governor1AccAddr.String(),
+			GovernorAddress:  govAddr2.String(),
+		},
+	}
+
+	require.NotPanics(t, func() {
+		gov.InitGenesis(ctx, suite.AccountKeeper, suite.BankKeeper, suite.GovKeeper, defaultState)
+	})
+}
+
 // TestInitGenesis_NonGovernorDelegation verifies that a non-governor account
 // can delegate to a governor.
 func TestInitGenesis_NonGovernorDelegation(t *testing.T) {

--- a/x/gov/genesis_test.go
+++ b/x/gov/genesis_test.go
@@ -2,6 +2,7 @@ package gov_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -9,6 +10,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/gov"
+	"github.com/cosmos/cosmos-sdk/x/gov/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
 
@@ -53,4 +55,46 @@ func TestImportExportQueues_ErrorUnconsistentState(t *testing.T) {
 	require.NotNil(t, genState.LastMinInitialDeposit)
 	require.NotEmpty(t, genState.LastMinDeposit.Value)
 	require.NotEmpty(t, genState.LastMinInitialDeposit.Value)
+}
+
+// TestInitGenesis_NonGovernorDelegation verifies that a non-governor account
+// can delegate to a governor. 
+func TestInitGenesis_NonGovernorDelegation(t *testing.T) {
+	suite := createTestSuite(t)
+	app := suite.App
+	ctx := app.BaseApp.NewContext(false)
+
+	// Create two accounts: one will be a governor, the other a plain delegator
+	governorPubKey := pubkeys[0]
+	delegatorPubKey := pubkeys[1]
+
+	governorAccAddr := sdk.AccAddress(governorPubKey.Address())
+	delegatorAccAddr := sdk.AccAddress(delegatorPubKey.Address())
+
+	// Register both accounts in the auth module
+	govAcc := suite.AccountKeeper.NewAccountWithAddress(ctx, governorAccAddr)
+	suite.AccountKeeper.SetAccount(ctx, govAcc)
+
+	delAcc := suite.AccountKeeper.NewAccountWithAddress(ctx, delegatorAccAddr)
+	suite.AccountKeeper.SetAccount(ctx, delAcc)
+
+	govAddr := types.GovernorAddress(governorAccAddr)
+	now := time.Now().UTC()
+
+	governor, err := v1.NewGovernor(govAddr.String(), v1.NewGovernorDescription("test-gov", "", "", "", ""), now)
+	require.NoError(t, err)
+
+	defaultState := v1.DefaultGenesisState()
+	defaultState.Governors = []*v1.Governor{&governor}
+	defaultState.GovernanceDelegations = []*v1.GovernanceDelegation{
+		{
+			DelegatorAddress: delegatorAccAddr.String(),
+			GovernorAddress:  govAddr.String(),
+		},
+	}
+
+
+	require.NotPanics(t, func() {
+		gov.InitGenesis(ctx, suite.AccountKeeper, suite.BankKeeper, suite.GovKeeper, defaultState)
+	})
 }

--- a/x/gov/genesis_test.go
+++ b/x/gov/genesis_test.go
@@ -58,7 +58,7 @@ func TestImportExportQueues_ErrorUnconsistentState(t *testing.T) {
 }
 
 // TestInitGenesis_NonGovernorDelegation verifies that a non-governor account
-// can delegate to a governor. 
+// can delegate to a governor.
 func TestInitGenesis_NonGovernorDelegation(t *testing.T) {
 	suite := createTestSuite(t)
 	app := suite.App
@@ -92,7 +92,6 @@ func TestInitGenesis_NonGovernorDelegation(t *testing.T) {
 			GovernorAddress:  govAddr.String(),
 		},
 	}
-
 
 	require.NotPanics(t, func() {
 		gov.InitGenesis(ctx, suite.AccountKeeper, suite.BankKeeper, suite.GovKeeper, defaultState)


### PR DESCRIPTION
An inverted check in genesis import could cause a panic.

Fix A-21