### PR TITLE
fix(x/staking): update existing validator commissions when commission params change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/gov) [#57](https://github.com/atomone-hub/cosmos-sdk/pull/57) Fix active governor check in hooks.
 * (x/gov) [#58](https://github.com/atomone-hub/cosmos-sdk/pull/58) Check errors in endblocker when traversing the quorum check queue.
 * (x/gov) [#59](https://github.com/atomone-hub/cosmos-sdk/pull/59) Ensure governor exists and is active before processing governance delegations.
+* (x/staking) [#83](https://github.com/atomone-hub/cosmos-sdk/pull/83) Update existing validator commissions when commission params change.
 
 ## [Unreleased]
 

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -614,5 +614,9 @@ func (k msgServer) UpdateParams(ctx context.Context, msg *types.MsgUpdateParams)
 		return nil, err
 	}
 
+	if err := k.UpdateValidatorCommissionsForNewRange(ctx, msg.Params.MinCommissionRate, msg.Params.MaxCommissionRate); err != nil {
+		return nil, err
+	}
+
 	return &types.MsgUpdateParamsResponse{}, nil
 }

--- a/x/staking/keeper/msg_server_test.go
+++ b/x/staking/keeper/msg_server_test.go
@@ -1143,3 +1143,77 @@ func (s *KeeperTestSuite) TestMsgUpdateParams() {
 		})
 	}
 }
+
+func (s *KeeperTestSuite) TestMsgUpdateParamsUpdatesExistingValidatorCommissions() {
+	ctx, keeper, msgServer := s.ctx, s.stakingKeeper, s.msgServer
+	require := s.Require()
+
+	minRate := math.LegacyMustNewDecFromStr("0.02")
+	maxRate := math.LegacyMustNewDecFromStr("0.05")
+	updatedAt := ctx.BlockTime().Add(-48 * time.Hour)
+
+	mustStoreValidator := func(index int, rate, maxRate, maxChangeRate math.LegacyDec) sdk.ValAddress {
+		valAddr := sdk.ValAddress(PKS[index].Address())
+		validator, err := stakingtypes.NewValidator(valAddr.String(), PKS[index], stakingtypes.Description{})
+		require.NoError(err)
+
+		validator.Commission = stakingtypes.NewCommissionWithTime(rate, maxRate, maxChangeRate, updatedAt)
+		require.NoError(keeper.SetValidator(ctx, validator))
+
+		return valAddr
+	}
+
+	lowAddr := mustStoreValidator(
+		0,
+		math.LegacyMustNewDecFromStr("0.01"),
+		math.LegacyMustNewDecFromStr("0.015"),
+		math.LegacyMustNewDecFromStr("0.01"),
+	)
+	highAddr := mustStoreValidator(
+		1,
+		math.LegacyMustNewDecFromStr("0.07"),
+		math.LegacyMustNewDecFromStr("0.10"),
+		math.LegacyMustNewDecFromStr("0.02"),
+	)
+	inRangeAddr := mustStoreValidator(
+		2,
+		math.LegacyMustNewDecFromStr("0.03"),
+		math.LegacyMustNewDecFromStr("0.04"),
+		math.LegacyMustNewDecFromStr("0.01"),
+	)
+
+	params := stakingtypes.DefaultParams()
+	params.MinCommissionRate = minRate
+	params.MaxCommissionRate = maxRate
+
+	_, err := msgServer.UpdateParams(ctx, &stakingtypes.MsgUpdateParams{
+		Authority: keeper.GetAuthority(),
+		Params:    params,
+	})
+	require.NoError(err)
+
+	storedParams, err := keeper.GetParams(ctx)
+	require.NoError(err)
+	require.Equal(params, storedParams)
+
+	lowValidator, err := keeper.GetValidator(ctx, lowAddr)
+	require.NoError(err)
+	require.True(minRate.Equal(lowValidator.Commission.Rate))
+	require.True(minRate.Equal(lowValidator.Commission.MaxRate))
+	require.True(math.LegacyMustNewDecFromStr("0.01").Equal(lowValidator.Commission.MaxChangeRate))
+	require.Equal(updatedAt, lowValidator.Commission.UpdateTime)
+
+	highValidator, err := keeper.GetValidator(ctx, highAddr)
+	require.NoError(err)
+	require.True(maxRate.Equal(highValidator.Commission.Rate))
+	require.True(math.LegacyMustNewDecFromStr("0.10").Equal(highValidator.Commission.MaxRate))
+	require.True(math.LegacyMustNewDecFromStr("0.02").Equal(highValidator.Commission.MaxChangeRate))
+	require.Equal(updatedAt, highValidator.Commission.UpdateTime)
+
+	inRangeValidator, err := keeper.GetValidator(ctx, inRangeAddr)
+	require.NoError(err)
+	require.True(math.LegacyMustNewDecFromStr("0.03").Equal(inRangeValidator.Commission.Rate))
+	require.True(math.LegacyMustNewDecFromStr("0.04").Equal(inRangeValidator.Commission.MaxRate))
+	require.True(math.LegacyMustNewDecFromStr("0.01").Equal(inRangeValidator.Commission.MaxChangeRate))
+	require.Equal(updatedAt, inRangeValidator.Commission.UpdateTime)
+}

--- a/x/staking/keeper/validator.go
+++ b/x/staking/keeper/validator.go
@@ -210,6 +210,49 @@ func (k Keeper) UpdateValidatorCommission(ctx context.Context,
 	return commission, nil
 }
 
+// UpdateValidatorCommissionsForNewRange updates stored validator commissions so
+// their current rate remains within the chain-wide bounds. If the enforced rate
+// ends up above a validator's MaxRate, MaxRate is lifted to match it.
+func (k Keeper) UpdateValidatorCommissionsForNewRange(
+	ctx context.Context, minRate, maxRate math.LegacyDec,
+) error {
+	validators, err := k.GetAllValidators(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, validator := range validators {
+		updatedRate := validator.Commission.Rate
+		switch {
+		case updatedRate.LT(minRate):
+			updatedRate = minRate
+		case updatedRate.GT(maxRate):
+			updatedRate = maxRate
+		}
+
+		changed := false
+		if !validator.Commission.Rate.Equal(updatedRate) {
+			validator.Commission.Rate = updatedRate
+			changed = true
+		}
+
+		if validator.Commission.MaxRate.LT(updatedRate) {
+			validator.Commission.MaxRate = updatedRate
+			changed = true
+		}
+
+		if !changed {
+			continue
+		}
+
+		if err := k.SetValidator(ctx, validator); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // RemoveValidator removes the validator record and associated indexes
 // except for the bonded validator index which is only handled in ApplyAndReturnTendermintUpdates
 func (k Keeper) RemoveValidator(ctx context.Context, address sdk.ValAddress) error {


### PR DESCRIPTION
close #75

### Description

Clamp existing validator commission rates to the new min/max range during `MsgUpdateParams`, raising a validator's `MaxRate` only when needed to keep the stored commission valid. Adds a regression test covering validators below, above, and within the updated range.