### PR TITLE
fix(x/gov/simulation): improve deposit throttlers generation to avoid empty `sdk.Coins`

### DIFF
--- a/x/gov/simulation/genesis.go
+++ b/x/gov/simulation/genesis.go
@@ -60,12 +60,13 @@ func GenDepositParamsDepositPeriod(r *rand.Rand) time.Duration {
 
 // GenDepositParamsMinDeposit returns randomized DepositParamsMinDeposit
 func GenDepositParamsMinDeposit(r *rand.Rand) sdk.Coins {
-	return sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, int64(simulation.RandIntBetween(r, 1, 1e3))))
+	return sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, int64(simulation.RandIntBetween(r, 100, 1e3))))
 }
 
-// GenDepositMinInitialRatio returns randomized DepositMinInitialRatio
+// GenDepositMinInitialDepositRatio returns a randomized ratio used to derive
+// minInitialDepositFloor from minDepositFloor
 func GenDepositMinInitialDepositRatio(r *rand.Rand) math.LegacyDec {
-	return math.LegacyNewDec(int64(simulation.RandIntBetween(r, 0, 99))).Quo(math.LegacyNewDec(100))
+	return math.LegacyNewDec(int64(simulation.RandIntBetween(r, 1, 100))).Quo(math.LegacyNewDec(100))
 }
 
 // GenVotingParamsVotingPeriod returns randomized VotingParamsVotingPeriod
@@ -277,6 +278,12 @@ func RandomizedGenState(simState *module.SimulationState) {
 	simState.AppParams.GetOrGenerate(
 		DepositParamsMinInitialDepositFloor, &minInitialDepositFloor, simState.Rand,
 		func(r *rand.Rand) {
+			// minInitialDepositFloor is derived from minDepositFloor by a random
+			// ratio in (0, 1). The generators are constrained so that
+			// `ratio x amount` truncated is always at least 1 for every coin
+			// in minDepositFloor (see GenDepositParamsMinDeposit and
+			// GenDepositMinInitialDepositRatio), so the result is guaranteed
+			// to be a valid, non-empty sdk.Coins.
 			ratio := GenDepositMinInitialDepositRatio(r)
 			minInitialDepositFloor = sdk.NewCoins()
 			for _, coin := range minDepositFloor {

--- a/x/gov/simulation/genesis_test.go
+++ b/x/gov/simulation/genesis_test.go
@@ -85,7 +85,7 @@ func TestRandomizedGenState(t *testing.T) {
 	require.Equal(t, []*v1.Proposal{}, govGenesis.Proposals)
 	require.Equal(t, "", govGenesis.Constitution)
 	require.Equal(t, v1.MinDepositThrottler{
-		FloorValue:                        sdk.NewCoins(sdk.NewCoin("stake", math.NewInt(631))),
+		FloorValue:                        sdk.NewCoins(sdk.NewCoin("stake", math.NewInt(811))),
 		UpdatePeriod:                      &minDepositUpdatePeriod,
 		TargetActiveProposals:             1,
 		DecreaseSensitivityTargetDistance: 3,
@@ -93,7 +93,7 @@ func TestRandomizedGenState(t *testing.T) {
 		DecreaseRatio:                     "0.050000000000000000",
 	}, *govGenesis.Params.MinDepositThrottler)
 	require.Equal(t, v1.MinInitialDepositThrottler{
-		FloorValue:                        sdk.NewCoins(sdk.NewCoin("stake", math.NewInt(201))),
+		FloorValue:                        sdk.NewCoins(sdk.NewCoin("stake", math.NewInt(267))),
 		UpdatePeriod:                      &minInitialDepositUpdatePeriod,
 		TargetProposals:                   29,
 		DecreaseSensitivityTargetDistance: 1,

--- a/x/gov/simulation/operations.go
+++ b/x/gov/simulation/operations.go
@@ -518,7 +518,7 @@ func randomDeposit(
 	minAmount := sdkmath.ZeroInt()
 	maxAmount := minDepositAmount
 	if initialDeposit {
-		minAmount = k.GetMinInitialDeposit(ctx)[denomIndex].Amount
+		minAmount = k.GetMinInitialDeposit(ctx).AmountOf(denom)
 	}
 
 	// min initial deposit and min deposit grow independently, which can result in


### PR DESCRIPTION
While doing unrelated work a failing simulation highlighted an issue with the current code:
since at generation time `minInitialDepositFloor` is derived from `minDepositFloor` and the previous value of the ratio by which `minDepositFloor` is multiplied could also be 0, `minInitialDepositFloor` could result in an empty `sdk.Coins()`.

This PR bumps slightly the min when generating `minDepositFloor` and also changes how the `MinInitialDepositRatio` is generated to not include 0.

Also, makes a minor change in operations.go to use `AmountOf(denom)` instead of `[denomIndex].Amount` which is fundamentally more correct (although with the fixes in genesis.go this should not be needed, but it's still cleaner)