### PR TITLE
fix(x/gov): keep governor `IsActive` in sync with min self-delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/gov) [#71](https://github.com/atomone-hub/cosmos-sdk/pull/71) Validate minimum self-delegation for imported governors in InitGenesis
 * (x/gov) [#87](https://github.com/atomone-hub/cosmos-sdk/pull/87) Add safeguard to prevent proposals to be added to the quorum check queue if functionality is disabled by setting `QuorumCheckCount` to 0.
 * (x/auth) [#96](https://github.com/atomone-hub/cosmos-sdk/pull/96) Update `address_by_id` endpoint to use `account_id` instead of deprecated `id`.
+* (x/gov) [#98](https://github.com/atomone-hub/cosmos-sdk/pull/98) Keep governor IsActive in sync with min self-delegation.
 
 ## [v0.50.15](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.50.15) - 2025-12-12
 

--- a/x/gov/genesis.go
+++ b/x/gov/genesis.go
@@ -2,6 +2,7 @@ package gov
 
 import (
 	"fmt"
+	"strings"
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/math"
@@ -167,19 +168,22 @@ func InitGenesis(ctx sdk.Context, ak types.AccountKeeper, bk types.BankKeeper, k
 	// track active governors to skip their self-delegations in the second loop
 	activeGovernors := make(map[string]struct{})
 	for _, governor := range data.Governors {
+		// defensive sanitization
+		governor.GovernorAddress = strings.ToLower(governor.GovernorAddress)
 		// check that base account exists
-		accAddr := sdk.AccAddress(governor.GetAddress())
+		govAddr := governor.GetAddress()
+		accAddr := sdk.AccAddress(govAddr.Bytes())
 		acc := ak.GetAccount(ctx, accAddr)
 		if acc == nil {
 			panic(fmt.Sprintf("account %s does not exist", accAddr.String()))
 		}
 
-		if err := k.Governors.Set(ctx, governor.GetAddress(), *governor); err != nil {
+		if err := k.Governors.Set(ctx, govAddr, *governor); err != nil {
 			panic(err)
 		}
 		if governor.IsActive() {
 			// validate min self-delegation
-			bondedTokens, err := k.GetGovernorBondedTokens(ctx, governor.GetAddress())
+			bondedTokens, err := k.GetGovernorBondedTokens(ctx, govAddr)
 			if err != nil {
 				panic(err)
 			}
@@ -187,10 +191,10 @@ func InitGenesis(ctx sdk.Context, ak types.AccountKeeper, bk types.BankKeeper, k
 				panic(types.ErrInsufficientGovernorDelegation.Wrapf("minimum self-delegation required: %s, total bonded tokens: %s", minSelfDelegation, bondedTokens))
 			}
 
-			activeGovernors[governor.GetAddress().String()] = struct{}{}
-			err = k.DelegateToGovernor(ctx, accAddr, governor.GetAddress())
+			activeGovernors[governor.GovernorAddress] = struct{}{}
+			err = k.DelegateToGovernor(ctx, accAddr, govAddr)
 			if err != nil {
-				panic(fmt.Sprintf("failed to delegate to governor %s: %v", governor.GetAddress().String(), err))
+				panic(fmt.Sprintf("failed to delegate to governor %s: %v", governor.GovernorAddress, err))
 			}
 		}
 	}
@@ -202,7 +206,7 @@ func InitGenesis(ctx sdk.Context, ak types.AccountKeeper, bk types.BankKeeper, k
 		// skip self-delegations for active governors (already handled in first loop)
 		delGovAddr := types.GovernorAddress(delAddr)
 		if delGovAddr.Equals(govAddr) {
-			if _, isActive := activeGovernors[delGovAddr.String()]; isActive {
+			if _, isActive := activeGovernors[delegation.GovernorAddress]; isActive {
 				continue
 			}
 		}

--- a/x/gov/keeper/delegation.go
+++ b/x/gov/keeper/delegation.go
@@ -61,6 +61,10 @@ func (keeper Keeper) IncreaseGovernorShares(ctx sdk.Context, governorAddr types.
 	if err := keeper.ValidatorSharesByGovernor.Set(ctx, collections.Join(governorAddr, validatorAddr), valShares); err != nil {
 		panic(err)
 	}
+	// keep the reverse index in sync
+	if err := keeper.GovernorsByValidator.Set(ctx, collections.Join(validatorAddr, governorAddr)); err != nil {
+		panic(err)
+	}
 }
 
 // DecreaseGovernorShares decreases the governor validator shares in the store
@@ -78,6 +82,10 @@ func (keeper Keeper) DecreaseGovernorShares(ctx sdk.Context, governorAddr types.
 	}
 	if share.Shares.IsZero() {
 		if err := keeper.ValidatorSharesByGovernor.Remove(ctx, collections.Join(governorAddr, validatorAddr)); err != nil {
+			panic(err)
+		}
+		// drop the reverse-index entry alongside the primary
+		if err := keeper.GovernorsByValidator.Remove(ctx, collections.Join(validatorAddr, governorAddr)); err != nil {
 			panic(err)
 		}
 	} else {

--- a/x/gov/keeper/delegation.go
+++ b/x/gov/keeper/delegation.go
@@ -47,7 +47,7 @@ func (keeper Keeper) RemoveGovernanceDelegation(ctx sdk.Context, delegatorAddr s
 	}
 }
 
-// IncreaseGovernorShares increases the governor validator shares in the store
+// IncreaseGovernorShares increases the cumulative gov-tracked shares for a (governor, validator) pair
 func (keeper Keeper) IncreaseGovernorShares(ctx sdk.Context, governorAddr types.GovernorAddress, validatorAddr sdk.ValAddress, shares math.LegacyDec) {
 	valShares, err := keeper.ValidatorSharesByGovernor.Get(ctx, collections.Join(governorAddr, validatorAddr))
 	if err != nil && !errors.Is(err, collections.ErrNotFound) {
@@ -61,13 +61,9 @@ func (keeper Keeper) IncreaseGovernorShares(ctx sdk.Context, governorAddr types.
 	if err := keeper.ValidatorSharesByGovernor.Set(ctx, collections.Join(governorAddr, validatorAddr), valShares); err != nil {
 		panic(err)
 	}
-	// keep the reverse index in sync
-	if err := keeper.GovernorsByValidator.Set(ctx, collections.Join(validatorAddr, governorAddr)); err != nil {
-		panic(err)
-	}
 }
 
-// DecreaseGovernorShares decreases the governor validator shares in the store
+// DecreaseGovernorShares decreases the cumulative gov-tracked shares for a (governor, validator) pair
 func (keeper Keeper) DecreaseGovernorShares(ctx sdk.Context, governorAddr types.GovernorAddress, validatorAddr sdk.ValAddress, shares math.LegacyDec) {
 	share, err := keeper.ValidatorSharesByGovernor.Get(ctx, collections.Join(governorAddr, validatorAddr))
 	if err != nil && !errors.Is(err, collections.ErrNotFound) {
@@ -84,10 +80,6 @@ func (keeper Keeper) DecreaseGovernorShares(ctx sdk.Context, governorAddr types.
 		if err := keeper.ValidatorSharesByGovernor.Remove(ctx, collections.Join(governorAddr, validatorAddr)); err != nil {
 			panic(err)
 		}
-		// drop the reverse-index entry alongside the primary
-		if err := keeper.GovernorsByValidator.Remove(ctx, collections.Join(validatorAddr, governorAddr)); err != nil {
-			panic(err)
-		}
 	} else {
 		if err := keeper.ValidatorSharesByGovernor.Set(ctx, collections.Join(governorAddr, validatorAddr), share); err != nil {
 			panic(err)
@@ -96,7 +88,9 @@ func (keeper Keeper) DecreaseGovernorShares(ctx sdk.Context, governorAddr types.
 }
 
 // UndelegateFromGovernor decreases all governor validator shares in the store
-// and then removes the governor delegation for the given delegator
+// and then removes the governor delegation for the given delegator. If the
+// delegator is the governor's account (self-delegation removal), remove the
+// ActiveGovernorsByDelegatedValidator entries as well.
 func (keeper Keeper) UndelegateFromGovernor(ctx sdk.Context, delegatorAddr sdk.AccAddress) error {
 	delegation, err := keeper.GovernanceDelegations.Get(ctx, delegatorAddr)
 	if err != nil && !errors.Is(err, collections.ErrNotFound) {
@@ -106,6 +100,7 @@ func (keeper Keeper) UndelegateFromGovernor(ctx sdk.Context, delegatorAddr sdk.A
 		return types.ErrGovernanceDelegationNotFound.Wrapf("governance delegation for delegator %s does not exist", delegatorAddr.String())
 	}
 	govAddr := types.MustGovernorAddressFromBech32(delegation.GovernorAddress)
+	isSelfDelegation := delegatorAddr.Equals(sdk.AccAddress(govAddr.Bytes()))
 	// iterate all delegations of delegator and decrease shares
 	err = keeper.sk.IterateDelegations(ctx, delegatorAddr, func(_ int64, delegation stakingtypes.DelegationI) (stop bool) {
 		valAddr, err := sdk.ValAddressFromBech32(delegation.GetValidatorAddr())
@@ -113,6 +108,11 @@ func (keeper Keeper) UndelegateFromGovernor(ctx sdk.Context, delegatorAddr sdk.A
 			panic(err) // This should never happen
 		}
 		keeper.DecreaseGovernorShares(ctx, govAddr, valAddr, delegation.GetShares())
+		if isSelfDelegation {
+			if err := keeper.ActiveGovernorsByDelegatedValidator.Remove(ctx, collections.Join(valAddr, govAddr)); err != nil {
+				panic(err)
+			}
+		}
 		return false
 	})
 	if err != nil {
@@ -124,10 +124,15 @@ func (keeper Keeper) UndelegateFromGovernor(ctx sdk.Context, delegatorAddr sdk.A
 }
 
 // DelegateGovernor creates a governor delegation for the given delegator
-// and increases all governor validator shares in the store
+// and increases all governor validator shares in the store. If the delegator
+// is the governor's account and the governor is active, the
+// ActiveGovernorsByDelegatedValidator entries are populated alongside.
+// CONTRACT: governance delegation can only be created if target governor is active
 func (keeper Keeper) DelegateToGovernor(ctx sdk.Context, delegatorAddr sdk.AccAddress, governorAddr types.GovernorAddress) error {
 	delegation := v1.NewGovernanceDelegation(delegatorAddr, governorAddr)
 	keeper.SetGovernanceDelegation(ctx, delegation)
+	// assume contract is upheld: target governor MUST be active
+	isActiveSelfDelegation := delegatorAddr.Equals(sdk.AccAddress(governorAddr.Bytes()))
 	// iterate all delegations of delegator and increase shares
 	err := keeper.sk.IterateDelegations(ctx, delegatorAddr, func(_ int64, delegation stakingtypes.DelegationI) (stop bool) {
 		valAddr, err := sdk.ValAddressFromBech32(delegation.GetValidatorAddr())
@@ -135,6 +140,11 @@ func (keeper Keeper) DelegateToGovernor(ctx sdk.Context, delegatorAddr sdk.AccAd
 			panic(err) // This should never happen
 		}
 		keeper.IncreaseGovernorShares(ctx, governorAddr, valAddr, delegation.GetShares())
+		if isActiveSelfDelegation {
+			if err := keeper.ActiveGovernorsByDelegatedValidator.Set(ctx, collections.Join(valAddr, governorAddr)); err != nil {
+				panic(err)
+			}
+		}
 		return false
 	})
 	if err != nil {
@@ -151,4 +161,42 @@ func (keeper Keeper) RedelegateToGovernor(ctx sdk.Context, delegatorAddr sdk.Acc
 	}
 	// delegate to the destination governor
 	return keeper.DelegateToGovernor(ctx, delegatorAddr, dstGovernorAddr)
+}
+
+// setActiveGovernorIndexEntries populates ActiveGovernorsByDelegatedValidator
+// for every validator the governor's own account currently delegates to. Used
+// when a governor transitions to active (genesis, MsgUpdateGovernorStatus).
+func (keeper Keeper) setActiveGovernorIndexEntries(ctx sdk.Context, govAddr types.GovernorAddress) error {
+	accAddr := sdk.AccAddress(govAddr.Bytes())
+	return keeper.sk.IterateDelegations(ctx, accAddr, func(_ int64, delegation stakingtypes.DelegationI) bool {
+		valAddr, err := sdk.ValAddressFromBech32(delegation.GetValidatorAddr())
+		if err != nil {
+			panic(err) // This should never happen
+		}
+		if err := keeper.ActiveGovernorsByDelegatedValidator.Set(ctx, collections.Join(valAddr, govAddr)); err != nil {
+			panic(err)
+		}
+		return false
+	})
+}
+
+// removeActiveGovernorIndexEntries clears every ActiveGovernorsByDelegatedValidator
+// entry that points to the given governor. Used on every active to inactive
+// transition to keep the active-only invariant.
+//
+// CONTRACT: the caller must not be iterating ActiveGovernorsByDelegatedValidator
+// at the same time (per the store iterator contract). Validator hooks use a
+// collect-then-deactivate pattern to satisfy this.
+func (keeper Keeper) removeActiveGovernorIndexEntries(ctx sdk.Context, govAddr types.GovernorAddress) error {
+	accAddr := sdk.AccAddress(govAddr.Bytes())
+	return keeper.sk.IterateDelegations(ctx, accAddr, func(_ int64, delegation stakingtypes.DelegationI) bool {
+		valAddr, err := sdk.ValAddressFromBech32(delegation.GetValidatorAddr())
+		if err != nil {
+			panic(err) // This should never happen
+		}
+		if err := keeper.ActiveGovernorsByDelegatedValidator.Remove(ctx, collections.Join(valAddr, govAddr)); err != nil {
+			panic(err)
+		}
+		return false
+	})
 }

--- a/x/gov/keeper/export_test.go
+++ b/x/gov/keeper/export_test.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/gov/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
 
@@ -20,4 +21,17 @@ func (keeper Keeper) ValidateInitialDeposit(ctx sdk.Context, initialDeposit sdk.
 // min-self-delegation validation for tests.
 func (keeper Keeper) ValidateGovernorMinSelfDelegationWithExclusions(ctx sdk.Context, governor v1.Governor, excludeValAddrs map[string]struct{}) bool {
 	return keeper.validateGovernorMinSelfDelegationWithExclusions(ctx, governor, excludeValAddrs)
+}
+
+// SetGovernorInactive exposes the private setGovernorInactive helper
+// (status flip + index cleanup) for tests that exercise the active→inactive
+// transition without driving it through a hook or message.
+func (keeper Keeper) SetGovernorInactive(ctx sdk.Context, governor v1.Governor) error {
+	return keeper.StakingHooks().setGovernorInactive(ctx, ctx, governor)
+}
+
+// SetActiveGovernorIndexEntries exposes the private index-backfill
+// helper for tests that exercise the inactive→active transition.
+func (keeper Keeper) SetActiveGovernorIndexEntries(ctx sdk.Context, govAddr types.GovernorAddress) error {
+	return keeper.setActiveGovernorIndexEntries(ctx, govAddr)
 }

--- a/x/gov/keeper/export_test.go
+++ b/x/gov/keeper/export_test.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/gov/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
 
@@ -21,17 +20,4 @@ func (keeper Keeper) ValidateInitialDeposit(ctx sdk.Context, initialDeposit sdk.
 // min-self-delegation validation for tests.
 func (keeper Keeper) ValidateGovernorMinSelfDelegationWithExclusions(ctx sdk.Context, governor v1.Governor, excludeValAddrs map[string]struct{}) bool {
 	return keeper.validateGovernorMinSelfDelegationWithExclusions(ctx, governor, excludeValAddrs)
-}
-
-// SetGovernorInactive exposes the private setGovernorInactive helper
-// (status flip + index cleanup) for tests that exercise the active→inactive
-// transition without driving it through a hook or message.
-func (keeper Keeper) SetGovernorInactive(ctx sdk.Context, governor v1.Governor) error {
-	return keeper.StakingHooks().setGovernorInactive(ctx, ctx, governor)
-}
-
-// SetActiveGovernorIndexEntries exposes the private index-backfill
-// helper for tests that exercise the inactive→active transition.
-func (keeper Keeper) SetActiveGovernorIndexEntries(ctx sdk.Context, govAddr types.GovernorAddress) error {
-	return keeper.setActiveGovernorIndexEntries(ctx, govAddr)
 }

--- a/x/gov/keeper/export_test.go
+++ b/x/gov/keeper/export_test.go
@@ -1,6 +1,9 @@
 package keeper
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+)
 
 // ValidateInitialDeposit is a helper function used only in deposit tests which returns the same
 // functionality of validateInitialDeposit private function.
@@ -11,4 +14,10 @@ func (keeper Keeper) ValidateInitialDeposit(ctx sdk.Context, initialDeposit sdk.
 	}
 
 	return keeper.validateInitialDeposit(ctx, params, initialDeposit)
+}
+
+// ValidateGovernorMinSelfDelegationWithExclusions exposes the private exclusion-aware
+// min-self-delegation validation for tests.
+func (keeper Keeper) ValidateGovernorMinSelfDelegationWithExclusions(ctx sdk.Context, governor v1.Governor, excludeValAddrs map[string]struct{}) bool {
+	return keeper.validateGovernorMinSelfDelegationWithExclusions(ctx, governor, excludeValAddrs)
 }

--- a/x/gov/keeper/fixture_test.go
+++ b/x/gov/keeper/fixture_test.go
@@ -137,7 +137,7 @@ func newFixture(t *testing.T, ctx sdk.Context, numVals, numDelegators,
 }
 
 // setValidatorStatus mutates the fixture-tracked validator's status. Used to simulate
-// post-transition state (e.g. Bonded → Unbonding) ahead of invoking a staking hook.
+// post-transition state (e.g. Bonded to Unbonding) ahead of invoking a staking hook.
 func (s *fixture) setValidatorStatus(valIdx int, status stakingtypes.BondStatus) {
 	s.validators[valIdx].Status = status
 }

--- a/x/gov/keeper/fixture_test.go
+++ b/x/gov/keeper/fixture_test.go
@@ -99,22 +99,22 @@ func newFixture(t *testing.T, ctx sdk.Context, numVals, numDelegators,
 				return nil
 			}).AnyTimes()
 	mocks.stakingKeeper.EXPECT().GetValidator(ctx, gomock.Any()).DoAndReturn(
-		func(ctx context.Context, addr sdk.ValAddress) (stakingtypes.ValidatorI, bool) {
+		func(ctx context.Context, addr sdk.ValAddress) (stakingtypes.Validator, error) {
 			for i := 0; i < len(valAddrs); i++ {
 				if valAddrs[i].String() == addr.String() {
-					return s.validators[i], true
+					return s.validators[i], nil
 				}
 			}
-			return nil, false
+			return stakingtypes.Validator{}, stakingtypes.ErrNoValidatorFound
 		}).AnyTimes()
 	mocks.stakingKeeper.EXPECT().GetDelegation(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, del sdk.AccAddress, val sdk.ValAddress) (stakingtypes.Delegation, bool) {
+		func(_ context.Context, del sdk.AccAddress, val sdk.ValAddress) (stakingtypes.Delegation, error) {
 			for _, d := range s.delegations {
 				if d.DelegatorAddress == del.String() && d.ValidatorAddress == val.String() {
-					return d, true
+					return d, nil
 				}
 			}
-			return stakingtypes.Delegation{}, false
+			return stakingtypes.Delegation{}, stakingtypes.ErrNoDelegation
 		}).AnyTimes()
 
 	// Create active governors
@@ -134,6 +134,12 @@ func newFixture(t *testing.T, ctx sdk.Context, numVals, numDelegators,
 	require.NoError(t, err)
 	s.inactiveGovernor = governor
 	return s
+}
+
+// setValidatorStatus mutates the fixture-tracked validator's status. Used to simulate
+// post-transition state (e.g. Bonded → Unbonding) ahead of invoking a staking hook.
+func (s *fixture) setValidatorStatus(valIdx int, status stakingtypes.BondStatus) {
+	s.validators[valIdx].Status = status
 }
 
 // delegate updates the tallyFixture delegations and validators fields.

--- a/x/gov/keeper/governor.go
+++ b/x/gov/keeper/governor.go
@@ -14,6 +14,11 @@ import (
 )
 
 func (keeper Keeper) GetGovernorBondedTokens(ctx sdk.Context, govAddr types.GovernorAddress) (bondedTokens math.Int, err error) {
+	return keeper.getGovernorBondedTokensWithExclusions(ctx, govAddr, map[string]struct{}{})
+}
+
+// getGovernorBondedTokensWithExclusions returns the total bonded tokens of a governor excluding the delegations to the specified validator addresses.
+func (keeper Keeper) getGovernorBondedTokensWithExclusions(ctx sdk.Context, govAddr types.GovernorAddress, excludeValAddrs map[string]struct{}) (bondedTokens math.Int, err error) {
 	bondedTokens = math.ZeroInt()
 	addr := sdk.AccAddress(govAddr)
 	err = keeper.sk.IterateDelegations(ctx, addr, func(_ int64, delegation stakingtypes.DelegationI) (stop bool) {
@@ -21,6 +26,12 @@ func (keeper Keeper) GetGovernorBondedTokens(ctx sdk.Context, govAddr types.Gove
 		if err != nil {
 			panic(err) // This should never happen
 		}
+
+		// if the delegation is to be excluded, skip it
+		if _, excluded := excludeValAddrs[validatorAddr.String()]; excluded {
+			return false
+		}
+
 		validator, err := keeper.sk.GetValidator(ctx, validatorAddr)
 		if err != nil {
 			panic(err) // This should never happen (a delegation to a non-existent validator should not be possible)
@@ -39,10 +50,32 @@ func (keeper Keeper) GetGovernorBondedTokens(ctx sdk.Context, govAddr types.Gove
 }
 
 func (keeper Keeper) ValidateGovernorMinSelfDelegation(ctx sdk.Context, governor v1.Governor) bool {
+	return keeper.validateGovernorMinSelfDelegationWithExclusions(ctx, governor, map[string]struct{}{})
+}
+
+// validateGovernorMinSelfDelegationWithExclusions validates that the governor meets the min self-delegation requirement discounting
+// the delegations with the excluded validator addresses.
+func (keeper Keeper) validateGovernorMinSelfDelegationWithExclusions(ctx sdk.Context, governor v1.Governor, excludeValAddrs map[string]struct{}) bool {
 	// ensure that the governor is active and that has a valid governance self-delegation
 	if !governor.IsActive() {
 		return false
 	}
+
+	bondedTokens, err := keeper.getGovernorBondedTokensWithExclusions(ctx, governor.GetAddress(), excludeValAddrs)
+	if err != nil {
+		return false
+	}
+
+	return keeper.validateGovernorMinSelfDelegationWithTotalBonded(ctx, governor, bondedTokens)
+}
+
+// validateGovernorMinSelfDelegationWithTotalBonded validates that the governor meets the min self-delegation requirement given the specified total bonded tokens
+func (keeper Keeper) validateGovernorMinSelfDelegationWithTotalBonded(ctx sdk.Context, governor v1.Governor, totalBonded math.Int) bool {
+	// ensure that the governor is active and that has a valid governance self-delegation
+	if !governor.IsActive() {
+		return false
+	}
+
 	params, err := keeper.Params.Get(ctx)
 	if err != nil {
 		panic(fmt.Sprintf("failed to get gov params: %v", err)) // This should never happen
@@ -51,17 +84,13 @@ func (keeper Keeper) ValidateGovernorMinSelfDelegation(ctx sdk.Context, governor
 	if !ok {
 		panic(fmt.Sprintf("invalid min governor self delegation: %s", params.MinGovernorSelfDelegation)) // This should never happen
 	}
-	bondedTokens, err := keeper.GetGovernorBondedTokens(ctx, governor.GetAddress())
-	if err != nil {
-		return false
-	}
-	delAddr := sdk.AccAddress(governor.GetAddress())
 
+	delAddr := sdk.AccAddress(governor.GetAddress())
 	if del, err := keeper.GovernanceDelegations.Get(ctx, delAddr); err != nil || governor.GovernorAddress != del.GovernorAddress {
 		panic("active governor without governance self-delegation")
 	}
 
-	if bondedTokens.LT(minGovernorSelfDelegation) {
+	if totalBonded.LT(minGovernorSelfDelegation) {
 		return false
 	}
 

--- a/x/gov/keeper/governor_test.go
+++ b/x/gov/keeper/governor_test.go
@@ -159,7 +159,7 @@ func TestEditGovernorDescriptionMerge(t *testing.T) {
 func TestValidateGovernorMinSelfDelegation(t *testing.T) {
 	tests := []struct {
 		name           string
-		setup          func(*fixture) v1.Governor
+		setup          func(*fixture) (v1.Governor, []sdk.ValAddress)
 		selfDelegation bool
 		valDelegations []stakingtypes.Delegation
 		expectedPanic  bool
@@ -167,54 +167,93 @@ func TestValidateGovernorMinSelfDelegation(t *testing.T) {
 	}{
 		{
 			name: "inactive governor",
-			setup: func(s *fixture) v1.Governor {
-				return s.inactiveGovernor
+			setup: func(s *fixture) (v1.Governor, []sdk.ValAddress) {
+				return s.inactiveGovernor, nil
 			},
 			expectedPanic: false,
 			expectedValid: false,
 		},
 		{
 			name: "active governor w/o self delegation w/o validator delegation",
-			setup: func(s *fixture) v1.Governor {
-				return s.activeGovernors[0]
+			setup: func(s *fixture) (v1.Governor, []sdk.ValAddress) {
+				return s.activeGovernors[0], nil
 			},
 			expectedPanic: true,
 			expectedValid: false,
 		},
 		{
 			name: "active governor w self delegation w/o validator delegation",
-			setup: func(s *fixture) v1.Governor {
+			setup: func(s *fixture) (v1.Governor, []sdk.ValAddress) {
 				govAddr := s.activeGovernors[0].GetAddress()
 				delAddr := sdk.AccAddress(govAddr)
 				err := s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr)
 				require.NoError(s.t, err)
-				return s.activeGovernors[0]
+				return s.activeGovernors[0], nil
 			},
 			expectedPanic: false,
 			expectedValid: false,
 		},
 		{
 			name: "active governor w self delegation w not enough validator delegation",
-			setup: func(s *fixture) v1.Governor {
+			setup: func(s *fixture) (v1.Governor, []sdk.ValAddress) {
 				govAddr := s.activeGovernors[0].GetAddress()
 				delAddr := sdk.AccAddress(govAddr)
 				err := s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr)
 				require.NoError(s.t, err)
 				s.delegate(delAddr, s.valAddrs[0], 1)
-				return s.activeGovernors[0]
+				return s.activeGovernors[0], nil
 			},
 			expectedPanic: false,
 			expectedValid: false,
 		},
 		{
 			name: "active governor w self delegation w enough validator delegation",
-			setup: func(s *fixture) v1.Governor {
+			setup: func(s *fixture) (v1.Governor, []sdk.ValAddress) {
 				govAddr := s.activeGovernors[0].GetAddress()
 				delAddr := sdk.AccAddress(govAddr)
 				err := s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr)
 				require.NoError(s.t, err)
 				s.delegate(delAddr, s.valAddrs[0], v1.DefaultMinGovernorSelfDelegation.Int64())
-				return s.activeGovernors[0]
+				return s.activeGovernors[0], nil
+			},
+			expectedPanic: false,
+			expectedValid: true,
+		},
+		{
+			name: "active governor meets threshold by sum across two validators, excluding one drops below",
+			setup: func(s *fixture) (v1.Governor, []sdk.ValAddress) {
+				govAddr := s.activeGovernors[0].GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				require.NoError(s.t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				half := v1.DefaultMinGovernorSelfDelegation.QuoRaw(2).Int64()
+				s.delegate(delAddr, s.valAddrs[0], half)
+				s.delegate(delAddr, s.valAddrs[1], half)
+				return s.activeGovernors[0], []sdk.ValAddress{s.valAddrs[0]}
+			},
+			expectedPanic: false,
+			expectedValid: false,
+		},
+		{
+			name: "active governor meets threshold, excluding a validator they don't delegate to is a no-op",
+			setup: func(s *fixture) (v1.Governor, []sdk.ValAddress) {
+				govAddr := s.activeGovernors[0].GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				require.NoError(s.t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				s.delegate(delAddr, s.valAddrs[0], v1.DefaultMinGovernorSelfDelegation.Int64())
+				return s.activeGovernors[0], []sdk.ValAddress{s.valAddrs[1]}
+			},
+			expectedPanic: false,
+			expectedValid: true,
+		},
+		{
+			name: "active governor meets threshold by remaining delegation alone, excluding the smaller one keeps active",
+			setup: func(s *fixture) (v1.Governor, []sdk.ValAddress) {
+				govAddr := s.activeGovernors[0].GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				require.NoError(s.t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				s.delegate(delAddr, s.valAddrs[0], 1)
+				s.delegate(delAddr, s.valAddrs[1], v1.DefaultMinGovernorSelfDelegation.Int64())
+				return s.activeGovernors[0], []sdk.ValAddress{s.valAddrs[0]}
 			},
 			expectedPanic: false,
 			expectedValid: true,
@@ -230,14 +269,21 @@ func TestValidateGovernorMinSelfDelegation(t *testing.T) {
 				distributionKeeper: distrKeeper,
 			}
 			s := newFixture(t, ctx, 2, 2, 2, govKeeper, mocks)
-			governor := tt.setup(s)
+			governor, exclusions := tt.setup(s)
+
+			excludeSet := map[string]struct{}{}
+			for _, valAddr := range exclusions {
+				excludeSet[valAddr.String()] = struct{}{}
+			}
 
 			if tt.expectedPanic {
-				assert.Panics(t, func() { govKeeper.ValidateGovernorMinSelfDelegation(ctx, governor) })
+				assert.Panics(t, func() {
+					govKeeper.ValidateGovernorMinSelfDelegationWithExclusions(ctx, governor, excludeSet)
+				})
 			} else {
-				valid := govKeeper.ValidateGovernorMinSelfDelegation(ctx, governor)
+				valid := govKeeper.ValidateGovernorMinSelfDelegationWithExclusions(ctx, governor, excludeSet)
 
-				assert.Equal(t, tt.expectedValid, valid, "return of ValidateGovernorMinSelfDelegation")
+				assert.Equal(t, tt.expectedValid, valid, "return of ValidateGovernorMinSelfDelegationWithExclusions")
 			}
 		})
 	}

--- a/x/gov/keeper/hooks.go
+++ b/x/gov/keeper/hooks.go
@@ -72,7 +72,7 @@ func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddre
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	// Calculate the new shares and update the Governor's shares
-	shares := delegation.Shares
+	shares := delegation.GetShares()
 	h.k.IncreaseGovernorShares(sdkCtx, govAddr, valAddr, shares)
 
 	// if the delegator is also an active governor, ensure min self-delegation requirement is met,
@@ -84,10 +84,7 @@ func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddre
 		}
 		// if the governor no longer meets the min self-delegation, set to inactive
 		if !h.k.ValidateGovernorMinSelfDelegation(sdkCtx, governor) {
-			governor.Status = v1.Inactive
-			now := sdkCtx.BlockTime()
-			governor.LastStatusChangeTime = &now
-			if err := h.k.Governors.Set(ctx, governor.GetAddress(), governor); err != nil {
+			if err := h.setGovernorInactive(ctx, sdkCtx, governor); err != nil {
 				return err
 			}
 		}
@@ -100,7 +97,7 @@ func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddre
 // We verify if the delegator is also an active governor and if so check
 // that the min self-delegation requirement is still met, otherwise set governor
 // status to inactive
-func (h Hooks) BeforeDelegationRemoved(ctx context.Context, delAddr sdk.AccAddress, _ sdk.ValAddress) error {
+func (h Hooks) BeforeDelegationRemoved(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
 	// if the delegator is also an active governor, ensure min self-delegation requirement is met,
 	// otherwise set governor to inactive
 	delGovAddr := types.GovernorAddress(delAddr.Bytes())
@@ -115,13 +112,14 @@ func (h Hooks) BeforeDelegationRemoved(ctx context.Context, delAddr sdk.AccAddre
 		if governor.GetAddress().String() != govDelegation.GovernorAddress {
 			panic("active governor delegating to another governor")
 		}
-		// if the governor no longer meets the min self-delegation, set to inactive
+
+		exclusion := map[string]struct{}{
+			valAddr.String(): {},
+		}
 		sdkCtx := sdk.UnwrapSDKContext(ctx)
-		if !h.k.ValidateGovernorMinSelfDelegation(sdkCtx, governor) {
-			governor.Status = v1.Inactive
-			now := sdkCtx.BlockTime()
-			governor.LastStatusChangeTime = &now
-			if err := h.k.Governors.Set(ctx, governor.GetAddress(), governor); err != nil {
+		// if the governor no longer meets the min self-delegation, set to inactive
+		if !h.k.validateGovernorMinSelfDelegationWithExclusions(sdkCtx, governor, exclusion) {
+			if err := h.setGovernorInactive(ctx, sdkCtx, governor); err != nil {
 				return err
 			}
 		}
@@ -130,8 +128,41 @@ func (h Hooks) BeforeDelegationRemoved(ctx context.Context, delAddr sdk.AccAddre
 	return nil
 }
 
-func (h Hooks) BeforeValidatorSlashed(_ context.Context, _ sdk.ValAddress, _ math.LegacyDec) error {
-	return nil
+// BeforeValidatorSlashed revalidates active governors that delegate to the slashed
+// validator. If the projected post-slash bonded amount falls below the minimum
+// self-delegation, the governor is set to inactive.
+func (h Hooks) BeforeValidatorSlashed(ctx context.Context, valAddr sdk.ValAddress, fraction math.LegacyDec) error {
+	validator, err := h.k.sk.GetValidator(ctx, valAddr)
+	if err != nil {
+		// validator no longer exists; nothing to revalidate
+		return nil
+	}
+	valTotalShares := validator.GetDelegatorShares()
+	if valTotalShares.IsZero() {
+		return nil
+	}
+	valBondedTokens := validator.GetBondedTokens()
+
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	return h.walkGovernorsForValidator(ctx, valAddr, func(govAddr types.GovernorAddress, governor v1.Governor) error {
+		delegation, err := h.k.sk.GetDelegation(ctx, sdk.AccAddress(govAddr), valAddr)
+		if err != nil {
+			// index pointed here but the delegation is gone: defensively skip
+			return nil
+		}
+		totalBonded, err := h.k.GetGovernorBondedTokens(sdkCtx, govAddr)
+		if err != nil {
+			return err
+		}
+		delBonded := delegation.GetShares().MulInt(valBondedTokens).Quo(valTotalShares)
+		slashImpact := delBonded.Mul(fraction).TruncateInt()
+		postSlashBonded := totalBonded.Sub(slashImpact)
+
+		if !h.k.validateGovernorMinSelfDelegationWithTotalBonded(sdkCtx, governor, postSlashBonded) {
+			return h.setGovernorInactive(ctx, sdkCtx, governor)
+		}
+		return nil
+	})
 }
 
 func (h Hooks) AfterValidatorCreated(_ context.Context, _ sdk.ValAddress) error {
@@ -150,8 +181,51 @@ func (h Hooks) AfterValidatorBonded(_ context.Context, _ sdk.ConsAddress, _ sdk.
 	return nil
 }
 
-func (h Hooks) AfterValidatorBeginUnbonding(_ context.Context, _ sdk.ConsAddress, _ sdk.ValAddress) error {
-	return nil
+// AfterValidatorBeginUnbonding revalidates active governors that delegate to a
+// validator transitioning from Bonded to Unbonding (jail or active-set turnover).
+// At hook time the validator's status is already Unbonding, so GetBondedTokens()
+// returns zero for it and the standard validation correctly observes the
+// post-transition bonded total — no exclusion or adjustment is needed.
+func (h Hooks) AfterValidatorBeginUnbonding(ctx context.Context, _ sdk.ConsAddress, valAddr sdk.ValAddress) error {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	return h.walkGovernorsForValidator(ctx, valAddr, func(govAddr types.GovernorAddress, governor v1.Governor) error {
+		if h.k.ValidateGovernorMinSelfDelegation(sdkCtx, governor) {
+			return nil
+		}
+		return h.setGovernorInactive(ctx, sdkCtx, governor)
+	})
+}
+
+// walkGovernorsForValidator iterates the reverse index for the given validator,
+// loads each active governor, and invokes fn. Inactive governors and missing
+// records are skipped — fn only runs for actionable, currently-active governors.
+func (h Hooks) walkGovernorsForValidator(
+	ctx context.Context,
+	valAddr sdk.ValAddress,
+	fn func(govAddr types.GovernorAddress, governor v1.Governor) error,
+) error {
+	rng := collections.NewPrefixedPairRange[sdk.ValAddress, types.GovernorAddress](valAddr)
+	return h.k.GovernorsByValidator.Walk(ctx, rng, func(key collections.Pair[sdk.ValAddress, types.GovernorAddress]) (bool, error) {
+		govAddr := key.K2()
+		governor, err := h.k.Governors.Get(ctx, govAddr)
+		if err != nil {
+			// index entry without a governor record: stale entry, skip
+			return false, nil
+		}
+		if !governor.IsActive() {
+			return false, nil
+		}
+		return false, fn(govAddr, governor)
+	})
+}
+
+// setGovernorInactive flips a governor's stored status to inactive and records
+// the change time.
+func (h Hooks) setGovernorInactive(ctx context.Context, sdkCtx sdk.Context, governor v1.Governor) error {
+	governor.Status = v1.Inactive
+	now := sdkCtx.BlockTime()
+	governor.LastStatusChangeTime = &now
+	return h.k.Governors.Set(ctx, governor.GetAddress(), governor)
 }
 
 func (h Hooks) BeforeDelegationCreated(_ context.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {

--- a/x/gov/keeper/hooks.go
+++ b/x/gov/keeper/hooks.go
@@ -148,8 +148,8 @@ func (h Hooks) BeforeValidatorSlashed(ctx context.Context, valAddr sdk.ValAddres
 		govAddr := governor.GetAddress()
 		delegation, err := h.k.sk.GetDelegation(ctx, sdk.AccAddress(govAddr), valAddr)
 		if err != nil {
-			// index pointed here but the delegation is gone: defensively skip
-			return nil
+			// the reverse index claims this governor delegates here but staking disagrees
+			panic("governor reverse index out of sync with staking delegation")
 		}
 		totalBonded, err := h.k.GetGovernorBondedTokens(sdkCtx, govAddr)
 		if err != nil {
@@ -198,8 +198,8 @@ func (h Hooks) AfterValidatorBeginUnbonding(ctx context.Context, _ sdk.ConsAddre
 }
 
 // walkGovernorsForValidator iterates the reverse index for the given validator,
-// loads each active governor, and invokes fn. Inactive governors and missing
-// records are skipped — fn only runs for actionable, currently-active governors.
+// loads each governor and invokes fn only for active ones. A missing governor
+// record for an index entry indicates state corruption and panics.
 func (h Hooks) walkGovernorsForValidator(
 	ctx context.Context,
 	valAddr sdk.ValAddress,
@@ -210,8 +210,8 @@ func (h Hooks) walkGovernorsForValidator(
 		govAddr := key.K2()
 		governor, err := h.k.Governors.Get(ctx, govAddr)
 		if err != nil {
-			// index entry without a governor record: stale entry, skip
-			return false, nil
+			// the reverse index points to a governor that doesn't exist
+			panic("governor reverse index references a non-existent governor")
 		}
 		if !governor.IsActive() {
 			return false, nil

--- a/x/gov/keeper/hooks.go
+++ b/x/gov/keeper/hooks.go
@@ -144,7 +144,8 @@ func (h Hooks) BeforeValidatorSlashed(ctx context.Context, valAddr sdk.ValAddres
 	valBondedTokens := validator.GetBondedTokens()
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	return h.walkGovernorsForValidator(ctx, valAddr, func(govAddr types.GovernorAddress, governor v1.Governor) error {
+	return h.walkGovernorsForValidator(ctx, valAddr, func(governor v1.Governor) error {
+		govAddr := governor.GetAddress()
 		delegation, err := h.k.sk.GetDelegation(ctx, sdk.AccAddress(govAddr), valAddr)
 		if err != nil {
 			// index pointed here but the delegation is gone: defensively skip
@@ -188,7 +189,7 @@ func (h Hooks) AfterValidatorBonded(_ context.Context, _ sdk.ConsAddress, _ sdk.
 // post-transition bonded total — no exclusion or adjustment is needed.
 func (h Hooks) AfterValidatorBeginUnbonding(ctx context.Context, _ sdk.ConsAddress, valAddr sdk.ValAddress) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	return h.walkGovernorsForValidator(ctx, valAddr, func(govAddr types.GovernorAddress, governor v1.Governor) error {
+	return h.walkGovernorsForValidator(ctx, valAddr, func(governor v1.Governor) error {
 		if h.k.ValidateGovernorMinSelfDelegation(sdkCtx, governor) {
 			return nil
 		}
@@ -202,7 +203,7 @@ func (h Hooks) AfterValidatorBeginUnbonding(ctx context.Context, _ sdk.ConsAddre
 func (h Hooks) walkGovernorsForValidator(
 	ctx context.Context,
 	valAddr sdk.ValAddress,
-	fn func(govAddr types.GovernorAddress, governor v1.Governor) error,
+	fn func(governor v1.Governor) error,
 ) error {
 	rng := collections.NewPrefixedPairRange[sdk.ValAddress, types.GovernorAddress](valAddr)
 	return h.k.GovernorsByValidator.Walk(ctx, rng, func(key collections.Pair[sdk.ValAddress, types.GovernorAddress]) (bool, error) {
@@ -215,7 +216,7 @@ func (h Hooks) walkGovernorsForValidator(
 		if !governor.IsActive() {
 			return false, nil
 		}
-		return false, fn(govAddr, governor)
+		return false, fn(governor)
 	})
 }
 

--- a/x/gov/keeper/keeper.go
+++ b/x/gov/keeper/keeper.go
@@ -68,6 +68,10 @@ type Keeper struct {
 	GovernanceDelegations                 collections.Map[sdk.AccAddress, v1.GovernanceDelegation]
 	GovernanceDelegationsByGovernor       collections.Map[collections.Pair[types.GovernorAddress, sdk.AccAddress], v1.GovernanceDelegation]
 	ValidatorSharesByGovernor             collections.Map[collections.Pair[types.GovernorAddress, sdk.ValAddress], v1.GovernorValShares]
+	// GovernorsByValidator is the reverse index of ValidatorSharesByGovernor, keyed by
+	// (validator, governor). Used to efficiently enumerate governors affected by a
+	// validator-state change (slash, begin-unbonding).
+	GovernorsByValidator collections.KeySet[collections.Pair[sdk.ValAddress, types.GovernorAddress]]
 }
 
 // GetAuthority returns the x/gov module's authority.
@@ -131,6 +135,7 @@ func NewKeeper(
 		GovernanceDelegations:                 collections.NewMap(sb, types.GovernanceDelegationKeyPrefix, "governance_delegations", sdk.AccAddressKey, codec.CollValue[v1.GovernanceDelegation](cdc)),
 		GovernanceDelegationsByGovernor:       collections.NewMap(sb, types.GovernanceDelegationsByGovernorKeyPrefix, "governance_delegations_by_governor", collections.PairKeyCodec(types.GovernorAddressKey, sdk.AccAddressKey), codec.CollValue[v1.GovernanceDelegation](cdc)),
 		ValidatorSharesByGovernor:             collections.NewMap(sb, types.ValidatorSharesByGovernorKeyPrefix, "validator_shares_by_governor", collections.PairKeyCodec(types.GovernorAddressKey, sdk.ValAddressKey), codec.CollValue[v1.GovernorValShares](cdc)),
+		GovernorsByValidator:                  collections.NewKeySet(sb, types.GovernorsByValidatorKeyPrefix, "governors_by_validator", collections.PairKeyCodec(sdk.ValAddressKey, types.GovernorAddressKey)),
 	}
 	schema, err := sb.Build()
 	if err != nil {

--- a/x/gov/keeper/keeper.go
+++ b/x/gov/keeper/keeper.go
@@ -68,10 +68,9 @@ type Keeper struct {
 	GovernanceDelegations                 collections.Map[sdk.AccAddress, v1.GovernanceDelegation]
 	GovernanceDelegationsByGovernor       collections.Map[collections.Pair[types.GovernorAddress, sdk.AccAddress], v1.GovernanceDelegation]
 	ValidatorSharesByGovernor             collections.Map[collections.Pair[types.GovernorAddress, sdk.ValAddress], v1.GovernorValShares]
-	// GovernorsByValidator is the reverse index of ValidatorSharesByGovernor, keyed by
-	// (validator, governor). Used to efficiently enumerate governors affected by a
+	// ActiveGovernorsByDelegatedValidator records governors that have staking delegations to a given validator. Used to efficiently enumerate governors affected by a
 	// validator-state change (slash, begin-unbonding).
-	GovernorsByValidator collections.KeySet[collections.Pair[sdk.ValAddress, types.GovernorAddress]]
+	ActiveGovernorsByDelegatedValidator collections.KeySet[collections.Pair[sdk.ValAddress, types.GovernorAddress]]
 }
 
 // GetAuthority returns the x/gov module's authority.
@@ -135,7 +134,7 @@ func NewKeeper(
 		GovernanceDelegations:                 collections.NewMap(sb, types.GovernanceDelegationKeyPrefix, "governance_delegations", sdk.AccAddressKey, codec.CollValue[v1.GovernanceDelegation](cdc)),
 		GovernanceDelegationsByGovernor:       collections.NewMap(sb, types.GovernanceDelegationsByGovernorKeyPrefix, "governance_delegations_by_governor", collections.PairKeyCodec(types.GovernorAddressKey, sdk.AccAddressKey), codec.CollValue[v1.GovernanceDelegation](cdc)),
 		ValidatorSharesByGovernor:             collections.NewMap(sb, types.ValidatorSharesByGovernorKeyPrefix, "validator_shares_by_governor", collections.PairKeyCodec(types.GovernorAddressKey, sdk.ValAddressKey), codec.CollValue[v1.GovernorValShares](cdc)),
-		GovernorsByValidator:                  collections.NewKeySet(sb, types.GovernorsByValidatorKeyPrefix, "governors_by_validator", collections.PairKeyCodec(sdk.ValAddressKey, types.GovernorAddressKey)),
+		ActiveGovernorsByDelegatedValidator:   collections.NewKeySet(sb, types.GovernorsByValidatorKeyPrefix, "governors_by_validator", collections.PairKeyCodec(sdk.ValAddressKey, types.GovernorAddressKey)),
 	}
 	schema, err := sb.Build()
 	if err != nil {

--- a/x/gov/keeper/msg_server.go
+++ b/x/gov/keeper/msg_server.go
@@ -489,17 +489,24 @@ func (k msgServer) UpdateGovernorStatus(goCtx context.Context, msg *v1.MsgUpdate
 			panic(err)
 		}
 		if errors.Is(err, collections.ErrNotFound) {
-			err := k.DelegateToGovernor(ctx, addr, govAddr)
-			if err != nil {
+			if err := k.DelegateToGovernor(ctx, addr, govAddr); err != nil {
 				return nil, err
 			}
 		} else if delegation.GovernorAddress != govAddr.String() {
-			err := k.RedelegateToGovernor(ctx, addr, govAddr)
-			if err != nil {
+			if err := k.RedelegateToGovernor(ctx, addr, govAddr); err != nil {
 				return nil, err
 			}
 		}
+		// transition to active: populate the ActiveGovernorsByDelegatedValidatorerse index for this governor
+		if err := k.setActiveGovernorIndexEntries(ctx, govAddr); err != nil {
+			return nil, err
+		}
 		status = govtypes.AttributeValueStatusActive
+	} else {
+		// transition to inactive: clear the ActiveGovernorsByDelegatedValidatorerse index for this governor
+		if err := k.removeActiveGovernorIndexEntries(ctx, govAddr); err != nil {
+			return nil, err
+		}
 	}
 
 	ctx.EventManager().EmitEvents(sdk.Events{

--- a/x/gov/keeper/msg_server.go
+++ b/x/gov/keeper/msg_server.go
@@ -497,13 +497,13 @@ func (k msgServer) UpdateGovernorStatus(goCtx context.Context, msg *v1.MsgUpdate
 				return nil, err
 			}
 		}
-		// transition to active: populate the ActiveGovernorsByDelegatedValidatorerse index for this governor
+		// transition to active: populate the ActiveGovernorsByDelegatedValidator index for this governor
 		if err := k.setActiveGovernorIndexEntries(ctx, govAddr); err != nil {
 			return nil, err
 		}
 		status = govtypes.AttributeValueStatusActive
 	} else {
-		// transition to inactive: clear the ActiveGovernorsByDelegatedValidatorerse index for this governor
+		// transition to inactive: clear the ActiveGovernorsByDelegatedValidator index for this governor
 		if err := k.removeActiveGovernorIndexEntries(ctx, govAddr); err != nil {
 			return nil, err
 		}

--- a/x/gov/keeper/staking_hooks.go
+++ b/x/gov/keeper/staking_hooks.go
@@ -49,13 +49,12 @@ func (h Hooks) BeforeDelegationSharesModified(ctx context.Context, delAddr sdk.A
 	return nil
 }
 
-// AfterDelegationModified is called when a delegation is created or modified
+// AfterDelegationModified is called when a delegation is created or modified.
 // We trigger a governor shares increase here adding all delegation shares.
 // It is balanced by the full-amount decrease in BeforeDelegationSharesModified.
-// If the delegator is the governor's account and the governor is active keep
-// ActiveGovernorsByDelegatedValidator index in sync. If the governor is no
-// longer meeting the min self-delegation after the modification, status is
-// flipped to inactive which also cleans up the index.
+// If the delegator is an active governor's account, revalidate min self-delegation
+// (flipping the governor inactive if it no longer holds) and keep the
+// ActiveGovernorsByDelegatedValidator index in sync.
 func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
 	// does the delegator have a governance delegation?
 	govDelegation, err := h.k.GovernanceDelegations.Get(ctx, delAddr)
@@ -97,14 +96,10 @@ func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddre
 		panic("active governor delegating to another governor")
 	}
 
-	// active governor self-delegation: keep ActiveGovernorsByDelegatedValidator index in sync and revalidate min self-delegation
-	if err := h.k.ActiveGovernorsByDelegatedValidator.Set(ctx, collections.Join(valAddr, delGovAddr)); err != nil {
-		return err
-	}
 	if !h.k.ValidateGovernorMinSelfDelegation(sdkCtx, governor) {
 		return h.setGovernorInactive(ctx, sdkCtx, governor)
 	}
-	return nil
+	return h.k.ActiveGovernorsByDelegatedValidator.Set(ctx, collections.Join(valAddr, delGovAddr))
 }
 
 // BeforeDelegationRemoved is called when a delegation is removed

--- a/x/gov/keeper/staking_hooks.go
+++ b/x/gov/keeper/staking_hooks.go
@@ -51,7 +51,11 @@ func (h Hooks) BeforeDelegationSharesModified(ctx context.Context, delAddr sdk.A
 
 // AfterDelegationModified is called when a delegation is created or modified
 // We trigger a governor shares increase here adding all delegation shares.
-// It is balanced by the full-amount decrease in BeforeDelegationSharesModified
+// It is balanced by the full-amount decrease in BeforeDelegationSharesModified.
+// If the delegator is the governor's account and the governor is active keep
+// ActiveGovernorsByDelegatedValidator index in sync. If the governor is no
+// longer meeting the min self-delegation after the modification, status is
+// flipped to inactive which also cleans up the index.
 func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
 	// does the delegator have a governance delegation?
 	govDelegation, err := h.k.GovernanceDelegations.Get(ctx, delAddr)
@@ -71,66 +75,90 @@ func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddre
 	govAddr := types.MustGovernorAddressFromBech32(govDelegation.GovernorAddress)
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	// Calculate the new shares and update the Governor's shares
-	shares := delegation.GetShares()
-	h.k.IncreaseGovernorShares(sdkCtx, govAddr, valAddr, shares)
+	h.k.IncreaseGovernorShares(sdkCtx, govAddr, valAddr, delegation.GetShares())
 
-	// if the delegator is also an active governor, ensure min self-delegation requirement is met,
-	// otherwise set governor to inactive
+	// is the delegator the governor of the gov delegation? (i.e. governor self-delegation)
 	delGovAddr := types.GovernorAddress(delAddr.Bytes())
-	if governor, err := h.k.Governors.Get(ctx, delGovAddr); err == nil && governor.IsActive() {
-		if governor.GetAddress().String() != govDelegation.GovernorAddress {
-			panic("active governor delegating to another governor")
-		}
-		// if the governor no longer meets the min self-delegation, set to inactive
-		if !h.k.ValidateGovernorMinSelfDelegation(sdkCtx, governor) {
-			if err := h.setGovernorInactive(ctx, sdkCtx, governor); err != nil {
-				return err
-			}
-		}
+	if !delGovAddr.Equals(govAddr) {
+		// regular gov delegator (not the governor), nothing more to do
+		return nil
 	}
 
+	// delegator is the governor
+	governor, err := h.k.Governors.Get(ctx, delGovAddr)
+	if err != nil {
+		return err
+	}
+	if !governor.IsActive() {
+		// inactive governor self-delegation: do not touch the index (active-only invariant)
+		return nil
+	}
+	if governor.GovernorAddress != govDelegation.GovernorAddress {
+		panic("active governor delegating to another governor")
+	}
+
+	// active governor self-delegation: keep ActiveGovernorsByDelegatedValidator index in sync and revalidate min self-delegation
+	if err := h.k.ActiveGovernorsByDelegatedValidator.Set(ctx, collections.Join(valAddr, delGovAddr)); err != nil {
+		return err
+	}
+	if !h.k.ValidateGovernorMinSelfDelegation(sdkCtx, governor) {
+		return h.setGovernorInactive(ctx, sdkCtx, governor)
+	}
 	return nil
 }
 
 // BeforeDelegationRemoved is called when a delegation is removed
 // We verify if the delegator is also an active governor and if so check
 // that the min self-delegation requirement is still met, otherwise set governor
-// status to inactive
+// status to inactive. Update the ActiveGovernorsByDelegatedValidator index accordingly.
 func (h Hooks) BeforeDelegationRemoved(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
-	// if the delegator is also an active governor, ensure min self-delegation requirement is met,
-	// otherwise set governor to inactive
 	delGovAddr := types.GovernorAddress(delAddr.Bytes())
-	if governor, err := h.k.Governors.Get(ctx, delGovAddr); err == nil && governor.IsActive() {
-		govDelegation, err := h.k.GovernanceDelegations.Get(ctx, delAddr)
-		if err != nil && !errors.Is(err, collections.ErrNotFound) {
-			return err
-		}
-		if errors.Is(err, collections.ErrNotFound) {
-			panic("active governor without governance self-delegation")
-		}
-		if governor.GetAddress().String() != govDelegation.GovernorAddress {
-			panic("active governor delegating to another governor")
-		}
-
-		exclusion := map[string]struct{}{
-			valAddr.String(): {},
-		}
-		sdkCtx := sdk.UnwrapSDKContext(ctx)
-		// if the governor no longer meets the min self-delegation, set to inactive
-		if !h.k.validateGovernorMinSelfDelegationWithExclusions(sdkCtx, governor, exclusion) {
-			if err := h.setGovernorInactive(ctx, sdkCtx, governor); err != nil {
-				return err
-			}
-		}
+	governor, err := h.k.Governors.Get(ctx, delGovAddr)
+	if errors.Is(err, collections.ErrNotFound) {
+		// not a governor, nothing to do
+		return nil
+	}
+	if err != nil {
+		return err
 	}
 
+	// the delegator is a governor (active or otherwise): drop the ActiveGovernorsByDelegatedValidator
+	// entry for this validator, since their own staking delegation here is going away
+	if err := h.k.ActiveGovernorsByDelegatedValidator.Remove(ctx, collections.Join(valAddr, delGovAddr)); err != nil {
+		return err
+	}
+
+	if !governor.IsActive() {
+		return nil
+	}
+
+	// active governor: revalidate against post-removal state
+	govDelegation, err := h.k.GovernanceDelegations.Get(ctx, delAddr)
+	if err != nil && !errors.Is(err, collections.ErrNotFound) {
+		return err
+	}
+	if errors.Is(err, collections.ErrNotFound) {
+		panic("active governor without governance self-delegation")
+	}
+	if governor.GovernorAddress != govDelegation.GovernorAddress {
+		panic("active governor delegating to another governor")
+	}
+
+	exclusion := map[string]struct{}{
+		valAddr.String(): {},
+	}
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	if !h.k.validateGovernorMinSelfDelegationWithExclusions(sdkCtx, governor, exclusion) {
+		return h.setGovernorInactive(ctx, sdkCtx, governor)
+	}
 	return nil
 }
 
 // BeforeValidatorSlashed revalidates active governors that delegate to the slashed
 // validator. If the projected post-slash bonded amount falls below the minimum
-// self-delegation, the governor is set to inactive.
+// self-delegation, the governor is set to inactive. Status flips and index
+// cleanup are deferred until after the index walk completes so we don't write
+// to the iterated domain (per the store-iterator contract).
 func (h Hooks) BeforeValidatorSlashed(ctx context.Context, valAddr sdk.ValAddress, fraction math.LegacyDec) error {
 	validator, err := h.k.sk.GetValidator(ctx, valAddr)
 	if err != nil {
@@ -144,12 +172,13 @@ func (h Hooks) BeforeValidatorSlashed(ctx context.Context, valAddr sdk.ValAddres
 	valBondedTokens := validator.GetBondedTokens()
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	return h.walkGovernorsForValidator(ctx, valAddr, func(governor v1.Governor) error {
+	var toDeactivate []v1.Governor
+	err = h.walkGovernorsForValidator(ctx, valAddr, func(governor v1.Governor) error {
 		govAddr := governor.GetAddress()
 		delegation, err := h.k.sk.GetDelegation(ctx, sdk.AccAddress(govAddr), valAddr)
 		if err != nil {
-			// the reverse index claims this governor delegates here but staking disagrees
-			panic("governor reverse index out of sync with staking delegation")
+			// the index claims this governor delegates here but staking disagrees
+			panic("active governor to validator index out of sync with staking delegation")
 		}
 		totalBonded, err := h.k.GetGovernorBondedTokens(sdkCtx, govAddr)
 		if err != nil {
@@ -160,10 +189,19 @@ func (h Hooks) BeforeValidatorSlashed(ctx context.Context, valAddr sdk.ValAddres
 		postSlashBonded := totalBonded.Sub(slashImpact)
 
 		if !h.k.validateGovernorMinSelfDelegationWithTotalBonded(sdkCtx, governor, postSlashBonded) {
-			return h.setGovernorInactive(ctx, sdkCtx, governor)
+			toDeactivate = append(toDeactivate, governor)
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+	for _, g := range toDeactivate {
+		if err := h.setGovernorInactive(ctx, sdkCtx, g); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (h Hooks) AfterValidatorCreated(_ context.Context, _ sdk.ValAddress) error {
@@ -183,50 +221,30 @@ func (h Hooks) AfterValidatorBonded(_ context.Context, _ sdk.ConsAddress, _ sdk.
 }
 
 // AfterValidatorBeginUnbonding revalidates active governors that delegate to a
-// validator transitioning from Bonded to Unbonding (jail or active-set turnover).
+// validator transitioning from Bonded to Unbonding.
 // At hook time the validator's status is already Unbonding, so GetBondedTokens()
 // returns zero for it and the standard validation correctly observes the
 // post-transition bonded total — no exclusion or adjustment is needed.
+// Status flips and index cleanup are deferred until after the index walk
+// completes (per the store-iterator contract).
 func (h Hooks) AfterValidatorBeginUnbonding(ctx context.Context, _ sdk.ConsAddress, valAddr sdk.ValAddress) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	return h.walkGovernorsForValidator(ctx, valAddr, func(governor v1.Governor) error {
-		if h.k.ValidateGovernorMinSelfDelegation(sdkCtx, governor) {
-			return nil
+	var toDeactivate []v1.Governor
+	err := h.walkGovernorsForValidator(ctx, valAddr, func(governor v1.Governor) error {
+		if !h.k.ValidateGovernorMinSelfDelegation(sdkCtx, governor) {
+			toDeactivate = append(toDeactivate, governor)
 		}
-		return h.setGovernorInactive(ctx, sdkCtx, governor)
+		return nil
 	})
-}
-
-// walkGovernorsForValidator iterates the reverse index for the given validator,
-// loads each governor and invokes fn only for active ones. A missing governor
-// record for an index entry indicates state corruption and panics.
-func (h Hooks) walkGovernorsForValidator(
-	ctx context.Context,
-	valAddr sdk.ValAddress,
-	fn func(governor v1.Governor) error,
-) error {
-	rng := collections.NewPrefixedPairRange[sdk.ValAddress, types.GovernorAddress](valAddr)
-	return h.k.GovernorsByValidator.Walk(ctx, rng, func(key collections.Pair[sdk.ValAddress, types.GovernorAddress]) (bool, error) {
-		govAddr := key.K2()
-		governor, err := h.k.Governors.Get(ctx, govAddr)
-		if err != nil {
-			// the reverse index points to a governor that doesn't exist
-			panic("governor reverse index references a non-existent governor")
+	if err != nil {
+		return err
+	}
+	for _, g := range toDeactivate {
+		if err := h.setGovernorInactive(ctx, sdkCtx, g); err != nil {
+			return err
 		}
-		if !governor.IsActive() {
-			return false, nil
-		}
-		return false, fn(governor)
-	})
-}
-
-// setGovernorInactive flips a governor's stored status to inactive and records
-// the change time.
-func (h Hooks) setGovernorInactive(ctx context.Context, sdkCtx sdk.Context, governor v1.Governor) error {
-	governor.Status = v1.Inactive
-	now := sdkCtx.BlockTime()
-	governor.LastStatusChangeTime = &now
-	return h.k.Governors.Set(ctx, governor.GetAddress(), governor)
+	}
+	return nil
 }
 
 func (h Hooks) BeforeDelegationCreated(_ context.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
@@ -235,4 +253,46 @@ func (h Hooks) BeforeDelegationCreated(_ context.Context, _ sdk.AccAddress, _ sd
 
 func (h Hooks) AfterUnbondingInitiated(_ context.Context, _ uint64) error {
 	return nil
+}
+
+// walkGovernorsForValidator iterates ActiveGovernorsByDelegatedValidator for
+// the given validator, loads each governor and invokes fn only for active
+// ones. A missing governor record for an index entry indicates state
+// corruption and panics.
+func (h Hooks) walkGovernorsForValidator(
+	ctx context.Context,
+	valAddr sdk.ValAddress,
+	fn func(governor v1.Governor) error,
+) error {
+	rng := collections.NewPrefixedPairRange[sdk.ValAddress, types.GovernorAddress](valAddr)
+	return h.k.ActiveGovernorsByDelegatedValidator.Walk(ctx, rng, func(key collections.Pair[sdk.ValAddress, types.GovernorAddress]) (bool, error) {
+		govAddr := key.K2()
+		governor, err := h.k.Governors.Get(ctx, govAddr)
+		if err != nil {
+			panic("ActiveGovernorsByDelegatedValidator references a non-existent governor")
+		}
+		if !governor.IsActive() {
+			return false, nil
+		}
+		return false, fn(governor)
+	})
+}
+
+// setGovernorInactive flips a governor's stored status to inactive, records
+// the change time, and clears every ActiveGovernorsByDelegatedValidator entry
+// the governor holds.
+//
+// CONTRACT: callers must not be mid-walk over ActiveGovernorsByDelegatedValidator
+// for this governor — that would write to the iterated domain and violate the
+// store iterator contract. Validator hooks use a collect-then-deactivate
+// pattern; other callers (AfterDelegationModified, BeforeDelegationRemoved)
+// are not iterating that collection.
+func (h Hooks) setGovernorInactive(ctx context.Context, sdkCtx sdk.Context, governor v1.Governor) error {
+	governor.Status = v1.Inactive
+	now := sdkCtx.BlockTime()
+	governor.LastStatusChangeTime = &now
+	if err := h.k.Governors.Set(ctx, governor.GetAddress(), governor); err != nil {
+		return err
+	}
+	return h.k.removeActiveGovernorIndexEntries(sdkCtx, governor.GetAddress())
 }

--- a/x/gov/keeper/staking_hooks_test.go
+++ b/x/gov/keeper/staking_hooks_test.go
@@ -1,0 +1,376 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/collections"
+	"cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	"github.com/cosmos/cosmos-sdk/x/gov/types"
+	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+// TestBeforeDelegationRemoved exercises the gov staking hook fired when a
+// delegation is about to be deleted from the staking store. The hook must
+// reevaluate the governor's min-self-delegation against the post-removal
+// state, otherwise a governor whose total only crossed the threshold via the
+// to-be-removed delegation would be left active (stale-active bug).
+func TestBeforeDelegationRemoved(t *testing.T) {
+	halfMin := v1.DefaultMinGovernorSelfDelegation.QuoRaw(2).Int64()
+	fullMin := v1.DefaultMinGovernorSelfDelegation.Int64()
+
+	tests := []struct {
+		name string
+		// setup returns (delegator account, validator whose delegation is about to be removed,
+		// governor address to inspect after the hook, expected active state after the hook).
+		// govAddr is the zero value if no governor should exist for the delegator.
+		setup func(*fixture) (delAddr sdk.AccAddress, valAddr sdk.ValAddress, govAddr types.GovernorAddress)
+		// expectActive is checked only when govAddr != zero
+		expectActive bool
+	}{
+		{
+			name: "stale-active regression: two delegations crossing threshold by sum, full unbond of one drops below",
+			setup: func(s *fixture) (sdk.AccAddress, sdk.ValAddress, types.GovernorAddress) {
+				govAddr := s.activeGovernors[0].GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				require.NoError(t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				s.delegate(delAddr, s.valAddrs[0], halfMin)
+				s.delegate(delAddr, s.valAddrs[1], halfMin)
+				return delAddr, s.valAddrs[0], govAddr
+			},
+			expectActive: false,
+		},
+		{
+			name: "remaining delegation alone meets threshold: stays active",
+			setup: func(s *fixture) (sdk.AccAddress, sdk.ValAddress, types.GovernorAddress) {
+				govAddr := s.activeGovernors[0].GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				require.NoError(t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				s.delegate(delAddr, s.valAddrs[0], 1)
+				s.delegate(delAddr, s.valAddrs[1], fullMin)
+				return delAddr, s.valAddrs[0], govAddr
+			},
+			expectActive: true,
+		},
+		{
+			name: "single delegation at threshold, full unbond drops below: goes inactive",
+			setup: func(s *fixture) (sdk.AccAddress, sdk.ValAddress, types.GovernorAddress) {
+				govAddr := s.activeGovernors[0].GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				require.NoError(t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				s.delegate(delAddr, s.valAddrs[0], fullMin)
+				return delAddr, s.valAddrs[0], govAddr
+			},
+			expectActive: false,
+		},
+		{
+			name: "already inactive governor: hook is a no-op",
+			setup: func(s *fixture) (sdk.AccAddress, sdk.ValAddress, types.GovernorAddress) {
+				govAddr := s.inactiveGovernor.GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				s.delegate(delAddr, s.valAddrs[0], fullMin)
+				return delAddr, s.valAddrs[0], govAddr
+			},
+			expectActive: false,
+		},
+		{
+			name: "non-governor delegator: hook is a no-op (no panic)",
+			setup: func(s *fixture) (sdk.AccAddress, sdk.ValAddress, types.GovernorAddress) {
+				delAddr := s.delAddrs[0]
+				s.delegate(delAddr, s.valAddrs[0], fullMin)
+				return delAddr, s.valAddrs[0], types.GovernorAddress{}
+			},
+			expectActive: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			govKeeper, accKeeper, bankKeeper, stakingKeeper, distrKeeper, _, ctx := setupGovKeeper(t, mockAccountKeeperExpectations)
+			s := newFixture(t, ctx, 2, 2, 2, govKeeper, mocks{
+				accKeeper:          accKeeper,
+				bankKeeper:         bankKeeper,
+				stakingKeeper:      stakingKeeper,
+				distributionKeeper: distrKeeper,
+			})
+
+			delAddr, valAddr, govAddr := tt.setup(s)
+
+			err := govKeeper.StakingHooks().BeforeDelegationRemoved(s.ctx, delAddr, valAddr)
+			require.NoError(t, err)
+
+			if len(govAddr) == 0 {
+				return
+			}
+			stored, err := govKeeper.Governors.Get(s.ctx, govAddr)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectActive, stored.IsActive(), "governor active status after BeforeDelegationRemoved")
+		})
+	}
+}
+
+// TestBeforeValidatorSlashed exercises the gov staking hook fired before a
+// validator is slashed. Active governors whose projected post-slash bonded
+// amount falls below the min self-delegation must be set to inactive.
+func TestBeforeValidatorSlashed(t *testing.T) {
+	fullMin := v1.DefaultMinGovernorSelfDelegation.Int64()
+	halfSlash := math.LegacyNewDecWithPrec(5, 1) // 0.5
+
+	tests := []struct {
+		name string
+		// setup returns (validator being slashed, slash fraction, governors to inspect, expected active states aligned with governors).
+		setup func(*fixture) (valAddr sdk.ValAddress, fraction math.LegacyDec, governors []types.GovernorAddress, expectActive []bool)
+	}{
+		{
+			name: "active governor barely meeting threshold, half slash drops below: goes inactive",
+			setup: func(s *fixture) (sdk.ValAddress, math.LegacyDec, []types.GovernorAddress, []bool) {
+				govAddr := s.activeGovernors[0].GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				s.delegate(delAddr, s.valAddrs[0], fullMin)
+				require.NoError(t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				return s.valAddrs[0], halfSlash, []types.GovernorAddress{govAddr}, []bool{false}
+			},
+		},
+		{
+			name: "active governor well above threshold, half slash still above: stays active",
+			setup: func(s *fixture) (sdk.ValAddress, math.LegacyDec, []types.GovernorAddress, []bool) {
+				govAddr := s.activeGovernors[0].GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				s.delegate(delAddr, s.valAddrs[0], 3*fullMin)
+				require.NoError(t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				return s.valAddrs[0], halfSlash, []types.GovernorAddress{govAddr}, []bool{true}
+			},
+		},
+		{
+			name: "active governor not delegated to slashed validator: stays active",
+			setup: func(s *fixture) (sdk.ValAddress, math.LegacyDec, []types.GovernorAddress, []bool) {
+				govAddr := s.activeGovernors[0].GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				s.delegate(delAddr, s.valAddrs[0], fullMin)
+				require.NoError(t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				// slash a different validator
+				return s.valAddrs[1], halfSlash, []types.GovernorAddress{govAddr}, []bool{true}
+			},
+		},
+		{
+			name: "inactive governor delegated to slashed validator: stays inactive (hook skips)",
+			setup: func(s *fixture) (sdk.ValAddress, math.LegacyDec, []types.GovernorAddress, []bool) {
+				govAddr := s.inactiveGovernor.GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				s.delegate(delAddr, s.valAddrs[0], fullMin)
+				// no DelegateToGovernor for inactive governor (they have no gov self-delegation);
+				// the hook walks the reverse index, which is empty for this case.
+				return s.valAddrs[0], halfSlash, []types.GovernorAddress{govAddr}, []bool{false}
+			},
+		},
+		{
+			name: "two active governors both at threshold delegated to same validator: both go inactive",
+			setup: func(s *fixture) (sdk.ValAddress, math.LegacyDec, []types.GovernorAddress, []bool) {
+				govAddrs := []types.GovernorAddress{
+					s.activeGovernors[0].GetAddress(),
+					s.activeGovernors[1].GetAddress(),
+				}
+				for _, govAddr := range govAddrs {
+					delAddr := sdk.AccAddress(govAddr)
+					s.delegate(delAddr, s.valAddrs[0], fullMin)
+					require.NoError(t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				}
+				return s.valAddrs[0], halfSlash, govAddrs, []bool{false, false}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			govKeeper, accKeeper, bankKeeper, stakingKeeper, distrKeeper, _, ctx := setupGovKeeper(t, mockAccountKeeperExpectations)
+			// numGovernors = 3 so newFixture creates 2 active + 1 inactive for the multi-governor case.
+			s := newFixture(t, ctx, 2, 2, 3, govKeeper, mocks{
+				accKeeper:          accKeeper,
+				bankKeeper:         bankKeeper,
+				stakingKeeper:      stakingKeeper,
+				distributionKeeper: distrKeeper,
+			})
+
+			valAddr, fraction, governors, expectActive := tt.setup(s)
+			require.Equal(t, len(governors), len(expectActive))
+
+			err := govKeeper.StakingHooks().BeforeValidatorSlashed(s.ctx, valAddr, fraction)
+			require.NoError(t, err)
+
+			for i, govAddr := range governors {
+				stored, err := govKeeper.Governors.Get(s.ctx, govAddr)
+				require.NoError(t, err)
+				assert.Equal(t, expectActive[i], stored.IsActive(),
+					"governor %s active status after BeforeValidatorSlashed", govAddr.String())
+			}
+		})
+	}
+}
+
+// TestAfterValidatorBeginUnbonding exercises the gov staking hook fired when a
+// validator transitions from Bonded to Unbonding. At hook time the validator's
+// status is already Unbonding, so GetBondedTokens() returns zero for it and the
+// standard validation observes the post-transition bonded total.
+func TestAfterValidatorBeginUnbonding(t *testing.T) {
+	fullMin := v1.DefaultMinGovernorSelfDelegation.Int64()
+
+	tests := []struct {
+		name  string
+		setup func(*fixture) (valAddr sdk.ValAddress, governors []types.GovernorAddress, expectActive []bool)
+	}{
+		{
+			name: "single-validator governor: validator unbonds → goes inactive",
+			setup: func(s *fixture) (sdk.ValAddress, []types.GovernorAddress, []bool) {
+				govAddr := s.activeGovernors[0].GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				s.delegate(delAddr, s.valAddrs[0], fullMin)
+				require.NoError(t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				s.setValidatorStatus(0, stakingtypes.Unbonding)
+				return s.valAddrs[0], []types.GovernorAddress{govAddr}, []bool{false}
+			},
+		},
+		{
+			name: "two-validator governor, only one unbonds, remainder meets threshold: stays active",
+			setup: func(s *fixture) (sdk.ValAddress, []types.GovernorAddress, []bool) {
+				govAddr := s.activeGovernors[0].GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				s.delegate(delAddr, s.valAddrs[0], 1)
+				s.delegate(delAddr, s.valAddrs[1], fullMin)
+				require.NoError(t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				s.setValidatorStatus(0, stakingtypes.Unbonding)
+				return s.valAddrs[0], []types.GovernorAddress{govAddr}, []bool{true}
+			},
+		},
+		{
+			name: "two-validator governor split equally, one unbonds drops below threshold: goes inactive",
+			setup: func(s *fixture) (sdk.ValAddress, []types.GovernorAddress, []bool) {
+				govAddr := s.activeGovernors[0].GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				half := v1.DefaultMinGovernorSelfDelegation.QuoRaw(2).Int64()
+				s.delegate(delAddr, s.valAddrs[0], half)
+				s.delegate(delAddr, s.valAddrs[1], half)
+				require.NoError(t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				s.setValidatorStatus(0, stakingtypes.Unbonding)
+				return s.valAddrs[0], []types.GovernorAddress{govAddr}, []bool{false}
+			},
+		},
+		{
+			name: "governor not delegated to unbonding validator: unchanged",
+			setup: func(s *fixture) (sdk.ValAddress, []types.GovernorAddress, []bool) {
+				govAddr := s.activeGovernors[0].GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				s.delegate(delAddr, s.valAddrs[0], fullMin)
+				require.NoError(t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				s.setValidatorStatus(1, stakingtypes.Unbonding)
+				return s.valAddrs[1], []types.GovernorAddress{govAddr}, []bool{true}
+			},
+		},
+		{
+			name: "inactive governor: hook skips (reverse index has no entry without gov self-delegation)",
+			setup: func(s *fixture) (sdk.ValAddress, []types.GovernorAddress, []bool) {
+				govAddr := s.inactiveGovernor.GetAddress()
+				delAddr := sdk.AccAddress(govAddr)
+				s.delegate(delAddr, s.valAddrs[0], fullMin)
+				s.setValidatorStatus(0, stakingtypes.Unbonding)
+				return s.valAddrs[0], []types.GovernorAddress{govAddr}, []bool{false}
+			},
+		},
+		{
+			name: "two governors at threshold sharing a validator: both go inactive when it unbonds",
+			setup: func(s *fixture) (sdk.ValAddress, []types.GovernorAddress, []bool) {
+				govAddrs := []types.GovernorAddress{
+					s.activeGovernors[0].GetAddress(),
+					s.activeGovernors[1].GetAddress(),
+				}
+				for _, govAddr := range govAddrs {
+					delAddr := sdk.AccAddress(govAddr)
+					s.delegate(delAddr, s.valAddrs[0], fullMin)
+					require.NoError(t, s.keeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+				}
+				s.setValidatorStatus(0, stakingtypes.Unbonding)
+				return s.valAddrs[0], govAddrs, []bool{false, false}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			govKeeper, accKeeper, bankKeeper, stakingKeeper, distrKeeper, _, ctx := setupGovKeeper(t, mockAccountKeeperExpectations)
+			s := newFixture(t, ctx, 2, 2, 3, govKeeper, mocks{
+				accKeeper:          accKeeper,
+				bankKeeper:         bankKeeper,
+				stakingKeeper:      stakingKeeper,
+				distributionKeeper: distrKeeper,
+			})
+
+			valAddr, governors, expectActive := tt.setup(s)
+			require.Equal(t, len(governors), len(expectActive))
+
+			err := govKeeper.StakingHooks().AfterValidatorBeginUnbonding(s.ctx, sdk.ConsAddress{}, valAddr)
+			require.NoError(t, err)
+
+			for i, govAddr := range governors {
+				stored, err := govKeeper.Governors.Get(s.ctx, govAddr)
+				require.NoError(t, err)
+				assert.Equal(t, expectActive[i], stored.IsActive(),
+					"governor %s active status after AfterValidatorBeginUnbonding", govAddr.String())
+			}
+		})
+	}
+}
+
+// TestGovernorsByValidatorIndex covers the reverse-index maintenance contract:
+// an entry exists in GovernorsByValidator iff a corresponding entry exists in
+// ValidatorSharesByGovernor. The index drives BeforeValidatorSlashed and
+// AfterValidatorBeginUnbonding lookups, so its integrity is load-bearing.
+func TestGovernorsByValidatorIndex(t *testing.T) {
+	govKeeper, accKeeper, bankKeeper, stakingKeeper, distrKeeper, _, ctx := setupGovKeeper(t, mockAccountKeeperExpectations)
+	s := newFixture(t, ctx, 2, 2, 2, govKeeper, mocks{
+		accKeeper:          accKeeper,
+		bankKeeper:         bankKeeper,
+		stakingKeeper:      stakingKeeper,
+		distributionKeeper: distrKeeper,
+	})
+
+	govAddr := s.activeGovernors[0].GetAddress()
+	delAddr := sdk.AccAddress(govAddr)
+	fullMin := v1.DefaultMinGovernorSelfDelegation.Int64()
+
+	// initial state: no entries
+	assertIndexed(t, ctx, govKeeper, s.valAddrs[0], govAddr, false)
+	assertIndexed(t, ctx, govKeeper, s.valAddrs[1], govAddr, false)
+
+	// stake to val[0] then delegate-to-governor: IncreaseGovernorShares fires and adds the index entry
+	s.delegate(delAddr, s.valAddrs[0], fullMin)
+	require.NoError(t, govKeeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
+	assertIndexed(t, ctx, govKeeper, s.valAddrs[0], govAddr, true)
+	assertIndexed(t, ctx, govKeeper, s.valAddrs[1], govAddr, false)
+
+	// add a second validator delegation through the hooks path: IncreaseGovernorShares adds the second index entry
+	s.delegate(delAddr, s.valAddrs[1], fullMin)
+	govKeeper.IncreaseGovernorShares(s.ctx, govAddr, s.valAddrs[1], math.LegacyNewDec(fullMin))
+	assertIndexed(t, ctx, govKeeper, s.valAddrs[0], govAddr, true)
+	assertIndexed(t, ctx, govKeeper, s.valAddrs[1], govAddr, true)
+
+	// partially decrease val[0]: entry remains while shares > 0
+	govKeeper.DecreaseGovernorShares(s.ctx, govAddr, s.valAddrs[0], math.LegacyNewDec(fullMin/2))
+	assertIndexed(t, ctx, govKeeper, s.valAddrs[0], govAddr, true)
+
+	// fully decrease val[0]: index entry must be removed alongside the primary record
+	govKeeper.DecreaseGovernorShares(s.ctx, govAddr, s.valAddrs[0], math.LegacyNewDec(fullMin-fullMin/2))
+	assertIndexed(t, ctx, govKeeper, s.valAddrs[0], govAddr, false)
+	assertIndexed(t, ctx, govKeeper, s.valAddrs[1], govAddr, true)
+}
+
+func assertIndexed(t *testing.T, ctx sdk.Context, k *keeper.Keeper, valAddr sdk.ValAddress, govAddr types.GovernorAddress, want bool) {
+	t.Helper()
+	has, err := k.GovernorsByValidator.Has(ctx, collections.Join(valAddr, govAddr))
+	require.NoError(t, err)
+	assert.Equal(t, want, has, "GovernorsByValidator[%s,%s]", valAddr.String(), govAddr.String())
+}

--- a/x/gov/keeper/staking_hooks_test.go
+++ b/x/gov/keeper/staking_hooks_test.go
@@ -164,8 +164,8 @@ func TestBeforeValidatorSlashed(t *testing.T) {
 				govAddr := s.inactiveGovernor.GetAddress()
 				delAddr := sdk.AccAddress(govAddr)
 				s.delegate(delAddr, s.valAddrs[0], fullMin)
-				// no DelegateToGovernor for inactive governor (they have no gov self-delegation);
-				// the hook walks the reverse index, which is empty for this case.
+				// no DelegateToGovernor for an inactive governor: the hook walks
+				// ActiveGovernorsByDelegatedValidator, which is empty for this case.
 				return s.valAddrs[0], halfSlash, []types.GovernorAddress{govAddr}, []bool{false}
 			},
 		},
@@ -272,7 +272,7 @@ func TestAfterValidatorBeginUnbonding(t *testing.T) {
 			},
 		},
 		{
-			name: "inactive governor: hook skips (reverse index has no entry without gov self-delegation)",
+			name: "inactive governor: hook skips (no index entry without an active gov self-delegation)",
 			setup: func(s *fixture) (sdk.ValAddress, []types.GovernorAddress, []bool) {
 				govAddr := s.inactiveGovernor.GetAddress()
 				delAddr := sdk.AccAddress(govAddr)
@@ -325,52 +325,149 @@ func TestAfterValidatorBeginUnbonding(t *testing.T) {
 	}
 }
 
-// TestGovernorsByValidatorIndex covers the reverse-index maintenance contract:
-// an entry exists in GovernorsByValidator iff a corresponding entry exists in
-// ValidatorSharesByGovernor. The index drives BeforeValidatorSlashed and
-// AfterValidatorBeginUnbonding lookups, so its integrity is load-bearing.
-func TestGovernorsByValidatorIndex(t *testing.T) {
-	govKeeper, accKeeper, bankKeeper, stakingKeeper, distrKeeper, _, ctx := setupGovKeeper(t, mockAccountKeeperExpectations)
-	s := newFixture(t, ctx, 2, 2, 2, govKeeper, mocks{
-		accKeeper:          accKeeper,
-		bankKeeper:         bankKeeper,
-		stakingKeeper:      stakingKeeper,
-		distributionKeeper: distrKeeper,
-	})
-
-	govAddr := s.activeGovernors[0].GetAddress()
-	delAddr := sdk.AccAddress(govAddr)
+// TestActiveGovernorsByDelegatedValidator exercises the full maintenance contract:
+// an entry exists for (val, gov) iff gov is an active governor whose own account
+// has a staking delegation to val. Each case runs a scenario through the production
+// hook / keeper surface, then asserts on the index entries, the cumulative shares
+// (where relevant), and the governor's active status.
+func TestActiveGovernorsByDelegatedValidator(t *testing.T) {
 	fullMin := v1.DefaultMinGovernorSelfDelegation.Int64()
 
-	// initial state: no entries
-	assertIndexed(t, ctx, govKeeper, s.valAddrs[0], govAddr, false)
-	assertIndexed(t, ctx, govKeeper, s.valAddrs[1], govAddr, false)
+	boolPtr := func(b bool) *bool { return &b }
 
-	// stake to val[0] then delegate-to-governor: IncreaseGovernorShares fires and adds the index entry
-	s.delegate(delAddr, s.valAddrs[0], fullMin)
-	require.NoError(t, govKeeper.DelegateToGovernor(s.ctx, delAddr, govAddr))
-	assertIndexed(t, ctx, govKeeper, s.valAddrs[0], govAddr, true)
-	assertIndexed(t, ctx, govKeeper, s.valAddrs[1], govAddr, false)
+	tests := []struct {
+		name string
+		// run drives the scenario and returns the governor whose state to inspect.
+		run func(t *testing.T, s *fixture, k *keeper.Keeper) types.GovernorAddress
+		// expectIndexed[i] is the expected presence in
+		// ActiveGovernorsByDelegatedValidator[s.valAddrs[i], gov].
+		expectIndexed map[int]bool
+		// expectCumulative[i] is the expected presence in
+		// ValidatorSharesByGovernor[gov, s.valAddrs[i]] (nil to skip).
+		expectCumulative map[int]bool
+		// expectActive: nil to skip
+		expectActive *bool
+	}{
+		{
+			name: "lifecycle: self-stake + DelegateToGovernor adds entry; AfterDelegationModified adds a second; BeforeDelegationRemoved drops the first",
+			run: func(t *testing.T, s *fixture, k *keeper.Keeper) types.GovernorAddress {
+				gov := s.activeGovernors[0].GetAddress()
+				acc := sdk.AccAddress(gov)
+				s.delegate(acc, s.valAddrs[0], fullMin)
+				require.NoError(t, k.DelegateToGovernor(s.ctx, acc, gov))
+				s.delegate(acc, s.valAddrs[1], fullMin)
+				require.NoError(t, k.StakingHooks().AfterDelegationModified(s.ctx, acc, s.valAddrs[1]))
+				// re-running AfterDelegationModified is idempotent
+				require.NoError(t, k.StakingHooks().AfterDelegationModified(s.ctx, acc, s.valAddrs[1]))
+				// full-unbond val[0]; val[1] keeps the governor above threshold
+				require.NoError(t, k.StakingHooks().BeforeDelegationRemoved(s.ctx, acc, s.valAddrs[0]))
+				return gov
+			},
+			expectIndexed: map[int]bool{0: false, 1: true},
+			expectActive:  boolPtr(true),
+		},
+		{
+			name: "gov-delegator does not pollute: governor stakes val[0]; a separate delegator stakes val[1] and gov-delegates to the governor",
+			run: func(t *testing.T, s *fixture, k *keeper.Keeper) types.GovernorAddress {
+				gov := s.activeGovernors[0].GetAddress()
+				acc := sdk.AccAddress(gov)
+				del := s.delAddrs[0]
+				s.delegate(acc, s.valAddrs[0], fullMin)
+				require.NoError(t, k.DelegateToGovernor(s.ctx, acc, gov))
+				s.delegate(del, s.valAddrs[1], fullMin)
+				require.NoError(t, k.DelegateToGovernor(s.ctx, del, gov))
+				return gov
+			},
+			expectIndexed:    map[int]bool{0: true, 1: false},
+			expectCumulative: map[int]bool{0: true, 1: true},
+		},
+		{
+			name: "non-governor delegator AfterDelegationModified must not error and must not add an index entry",
+			run: func(t *testing.T, s *fixture, k *keeper.Keeper) types.GovernorAddress {
+				gov := s.activeGovernors[0].GetAddress()
+				acc := sdk.AccAddress(gov)
+				del := s.delAddrs[0]
+				s.delegate(acc, s.valAddrs[0], fullMin)
+				require.NoError(t, k.DelegateToGovernor(s.ctx, acc, gov))
+				s.delegate(del, s.valAddrs[1], fullMin)
+				require.NoError(t, k.DelegateToGovernor(s.ctx, del, gov))
+				// explicit re-fire of the staking hook with a non-governor delegator
+				require.NoError(t, k.StakingHooks().AfterDelegationModified(s.ctx, del, s.valAddrs[1]))
+				return gov
+			},
+			expectIndexed: map[int]bool{0: true, 1: false},
+		},
+		{
+			name: "governor full-unbonds val[0] while a delegator still stakes there: cumulative stays, index entry is removed",
+			run: func(t *testing.T, s *fixture, k *keeper.Keeper) types.GovernorAddress {
+				gov := s.activeGovernors[0].GetAddress()
+				acc := sdk.AccAddress(gov)
+				del := s.delAddrs[0]
+				// val[1] keeps the governor above threshold after the val[0] unbond
+				s.delegate(acc, s.valAddrs[0], fullMin)
+				s.delegate(acc, s.valAddrs[1], fullMin)
+				require.NoError(t, k.DelegateToGovernor(s.ctx, acc, gov))
+				// delegator also stakes to val[0] so cumulative > governor's own
+				s.delegate(del, s.valAddrs[0], fullMin)
+				require.NoError(t, k.DelegateToGovernor(s.ctx, del, gov))
+				require.NoError(t, k.StakingHooks().BeforeDelegationRemoved(s.ctx, acc, s.valAddrs[0]))
+				return gov
+			},
+			expectIndexed:    map[int]bool{0: false, 1: true},
+			expectCumulative: map[int]bool{0: true, 1: true},
+			expectActive:     boolPtr(true),
+		},
+		{
+			name: "status flip: deactivation clears all entries; reactivation backfills from current staking",
+			run: func(t *testing.T, s *fixture, k *keeper.Keeper) types.GovernorAddress {
+				gov := s.activeGovernors[0].GetAddress()
+				acc := sdk.AccAddress(gov)
+				s.delegate(acc, s.valAddrs[0], fullMin)
+				s.delegate(acc, s.valAddrs[1], fullMin)
+				require.NoError(t, k.DelegateToGovernor(s.ctx, acc, gov))
+				governor, err := k.Governors.Get(s.ctx, gov)
+				require.NoError(t, err)
+				require.NoError(t, k.SetGovernorInactive(s.ctx, governor))
+				// at this point both entries should be cleared; backfill restores them
+				require.NoError(t, k.SetActiveGovernorIndexEntries(s.ctx, gov))
+				return gov
+			},
+			expectIndexed: map[int]bool{0: true, 1: true},
+		},
+	}
 
-	// add a second validator delegation through the hooks path: IncreaseGovernorShares adds the second index entry
-	s.delegate(delAddr, s.valAddrs[1], fullMin)
-	govKeeper.IncreaseGovernorShares(s.ctx, govAddr, s.valAddrs[1], math.LegacyNewDec(fullMin))
-	assertIndexed(t, ctx, govKeeper, s.valAddrs[0], govAddr, true)
-	assertIndexed(t, ctx, govKeeper, s.valAddrs[1], govAddr, true)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			govKeeper, accKeeper, bankKeeper, stakingKeeper, distrKeeper, _, ctx := setupGovKeeper(t, mockAccountKeeperExpectations)
+			s := newFixture(t, ctx, 2, 2, 2, govKeeper, mocks{
+				accKeeper:          accKeeper,
+				bankKeeper:         bankKeeper,
+				stakingKeeper:      stakingKeeper,
+				distributionKeeper: distrKeeper,
+			})
 
-	// partially decrease val[0]: entry remains while shares > 0
-	govKeeper.DecreaseGovernorShares(s.ctx, govAddr, s.valAddrs[0], math.LegacyNewDec(fullMin/2))
-	assertIndexed(t, ctx, govKeeper, s.valAddrs[0], govAddr, true)
+			gov := tt.run(t, s, govKeeper)
 
-	// fully decrease val[0]: index entry must be removed alongside the primary record
-	govKeeper.DecreaseGovernorShares(s.ctx, govAddr, s.valAddrs[0], math.LegacyNewDec(fullMin-fullMin/2))
-	assertIndexed(t, ctx, govKeeper, s.valAddrs[0], govAddr, false)
-	assertIndexed(t, ctx, govKeeper, s.valAddrs[1], govAddr, true)
+			for valIdx, want := range tt.expectIndexed {
+				assertIndexed(t, ctx, govKeeper, s.valAddrs[valIdx], gov, want)
+			}
+			for valIdx, want := range tt.expectCumulative {
+				has, err := govKeeper.ValidatorSharesByGovernor.Has(s.ctx, collections.Join(gov, s.valAddrs[valIdx]))
+				require.NoError(t, err)
+				assert.Equal(t, want, has, "ValidatorSharesByGovernor[%s,%s]", gov.String(), s.valAddrs[valIdx].String())
+			}
+			if tt.expectActive != nil {
+				stored, err := govKeeper.Governors.Get(s.ctx, gov)
+				require.NoError(t, err)
+				assert.Equal(t, *tt.expectActive, stored.IsActive(), "governor active status")
+			}
+		})
+	}
 }
 
 func assertIndexed(t *testing.T, ctx sdk.Context, k *keeper.Keeper, valAddr sdk.ValAddress, govAddr types.GovernorAddress, want bool) {
 	t.Helper()
-	has, err := k.GovernorsByValidator.Has(ctx, collections.Join(valAddr, govAddr))
+	has, err := k.ActiveGovernorsByDelegatedValidator.Has(ctx, collections.Join(valAddr, govAddr))
 	require.NoError(t, err)
-	assert.Equal(t, want, has, "GovernorsByValidator[%s,%s]", valAddr.String(), govAddr.String())
+	assert.Equal(t, want, has, "ActiveGovernorsByDelegatedValidator[%s,%s]", valAddr.String(), govAddr.String())
 }

--- a/x/gov/keeper/staking_hooks_test.go
+++ b/x/gov/keeper/staking_hooks_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -225,7 +226,7 @@ func TestAfterValidatorBeginUnbonding(t *testing.T) {
 		setup func(*fixture) (valAddr sdk.ValAddress, governors []types.GovernorAddress, expectActive []bool)
 	}{
 		{
-			name: "single-validator governor: validator unbonds → goes inactive",
+			name: "single-validator governor: validator unbonds, governor goes inactive",
 			setup: func(s *fixture) (sdk.ValAddress, []types.GovernorAddress, []bool) {
 				govAddr := s.activeGovernors[0].GetAddress()
 				delAddr := sdk.AccAddress(govAddr)
@@ -418,21 +419,52 @@ func TestActiveGovernorsByDelegatedValidator(t *testing.T) {
 			expectActive:     boolPtr(true),
 		},
 		{
-			name: "status flip: deactivation clears all entries; reactivation backfills from current staking",
+			name: "MsgUpdateGovernorStatus active to inactive clears every index entry the governor holds",
 			run: func(t *testing.T, s *fixture, k *keeper.Keeper) types.GovernorAddress {
 				gov := s.activeGovernors[0].GetAddress()
 				acc := sdk.AccAddress(gov)
 				s.delegate(acc, s.valAddrs[0], fullMin)
 				s.delegate(acc, s.valAddrs[1], fullMin)
 				require.NoError(t, k.DelegateToGovernor(s.ctx, acc, gov))
-				governor, err := k.Governors.Get(s.ctx, gov)
+				allowImmediateStatusChange(t, s, k, gov)
+				msgServer := keeper.NewMsgServerImpl(k)
+				_, err := msgServer.UpdateGovernorStatus(s.ctx, &v1.MsgUpdateGovernorStatus{
+					Address: sdk.AccAddress(gov).String(),
+					Status:  v1.Inactive,
+				})
 				require.NoError(t, err)
-				require.NoError(t, k.SetGovernorInactive(s.ctx, governor))
-				// at this point both entries should be cleared; backfill restores them
-				require.NoError(t, k.SetActiveGovernorIndexEntries(s.ctx, gov))
+				return gov
+			},
+			expectIndexed: map[int]bool{0: false, 1: false},
+			expectActive:  boolPtr(false),
+		},
+		{
+			name: "MsgUpdateGovernorStatus inactive to active backfills the index from the governor's current staking",
+			run: func(t *testing.T, s *fixture, k *keeper.Keeper) types.GovernorAddress {
+				gov := s.activeGovernors[0].GetAddress()
+				acc := sdk.AccAddress(gov)
+				s.delegate(acc, s.valAddrs[0], fullMin)
+				s.delegate(acc, s.valAddrs[1], fullMin)
+				require.NoError(t, k.DelegateToGovernor(s.ctx, acc, gov))
+				allowImmediateStatusChange(t, s, k, gov)
+				msgServer := keeper.NewMsgServerImpl(k)
+				// deactivate so the active-to-inactive cleanup runs first; the gov
+				// self-delegation persists, so the reactivation hits the
+				// setActiveGovernorIndexEntries branch (not DelegateToGovernor).
+				_, err := msgServer.UpdateGovernorStatus(s.ctx, &v1.MsgUpdateGovernorStatus{
+					Address: sdk.AccAddress(gov).String(),
+					Status:  v1.Inactive,
+				})
+				require.NoError(t, err)
+				_, err = msgServer.UpdateGovernorStatus(s.ctx, &v1.MsgUpdateGovernorStatus{
+					Address: sdk.AccAddress(gov).String(),
+					Status:  v1.Active,
+				})
+				require.NoError(t, err)
 				return gov
 			},
 			expectIndexed: map[int]bool{0: true, 1: true},
+			expectActive:  boolPtr(true),
 		},
 	}
 
@@ -470,4 +502,22 @@ func assertIndexed(t *testing.T, ctx sdk.Context, k *keeper.Keeper, valAddr sdk.
 	has, err := k.ActiveGovernorsByDelegatedValidator.Has(ctx, collections.Join(valAddr, govAddr))
 	require.NoError(t, err)
 	assert.Equal(t, want, has, "ActiveGovernorsByDelegatedValidator[%s,%s]", valAddr.String(), govAddr.String())
+}
+
+// allowImmediateStatusChange zeroes GovernorStatusChangePeriod and pushes the
+// governor's LastStatusChangeTime into the past so a test can flip status via
+// MsgUpdateGovernorStatus without waiting out the cooldown.
+func allowImmediateStatusChange(t *testing.T, s *fixture, k *keeper.Keeper, govAddr types.GovernorAddress) {
+	t.Helper()
+	params, err := k.Params.Get(s.ctx)
+	require.NoError(t, err)
+	zero := time.Duration(0)
+	params.GovernorStatusChangePeriod = &zero
+	require.NoError(t, k.Params.Set(s.ctx, params))
+
+	g, err := k.Governors.Get(s.ctx, govAddr)
+	require.NoError(t, err)
+	past := s.ctx.BlockTime().Add(-time.Hour)
+	g.LastStatusChangeTime = &past
+	require.NoError(t, k.Governors.Set(s.ctx, govAddr, g))
 }

--- a/x/gov/types/keys.go
+++ b/x/gov/types/keys.go
@@ -39,6 +39,7 @@ var (
 	GovernanceDelegationKeyPrefix            = collections.NewPrefix(129)
 	ValidatorSharesByGovernorKeyPrefix       = collections.NewPrefix(130)
 	GovernanceDelegationsByGovernorKeyPrefix = collections.NewPrefix(131)
+	GovernorsByValidatorKeyPrefix            = collections.NewPrefix(132)
 
 	// GovernorAddressKey follows the same semantics as AccAddressKey.
 	GovernorAddressKey collcodec.KeyCodec[GovernorAddress] = governorAddressKey{


### PR DESCRIPTION
An active governor's `IsActive()` flag could drift out of sync with `ValidateGovernorMinSelfDelegation` whenever the governor's bonded tokens dropped: full self-unbond (stale read in the existing hook), slash, or the validator transitioning Bonded -> Unbonding. 

Tally was always safe (it re-runs the validation), but `MsgDelegateGovernor` accepts on the stored `Active` flag without explicit validation, leaving a UX/redelegation hole.

The fix re-evaluates min self-delegation on every path that can lower a governor's bonded total: the existing `BeforeDelegationRemoved` hook is corrected to look at post-removal state, and two new hooks (`BeforeValidatorSlashed`, `AfterValidatorBeginUnbonding`) cover the validator-side paths. A `ActiveGovernorsByDelegatedValidator ` index keeps each hook of the appropriate complexity considering only governors involved (absence would have required to walk all governors otherwise).