### PR TITLE
chore(x/upgrade): import cosmos-sdk v0.500.0

### DIFF
--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/cometbft/cometbft v0.38.20
 	github.com/cosmos/cosmos-db v1.1.1
 	// this version is not used as it is always replaced by the latest Cosmos SDK version
-	github.com/cosmos/cosmos-sdk v0.50.14
+	github.com/cosmos/cosmos-sdk v0.500.0
 	github.com/cosmos/gogoproto v1.7.0
 	github.com/spf13/cast v1.9.2 // indirect
 	github.com/spf13/cobra v1.9.1

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5 // indirect
 	// this version is not used as it is always replaced by the latest Cosmos SDK version
-	github.com/cosmos/cosmos-sdk v0.50.14
+	github.com/cosmos/cosmos-sdk v0.500.0
 	github.com/cosmos/gogoproto v1.7.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0

--- a/x/upgrade/go.mod
+++ b/x/upgrade/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/cometbft/cometbft v0.38.20
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
-	github.com/cosmos/cosmos-sdk v0.50.14
+	github.com/cosmos/cosmos-sdk v0.500.0
 	github.com/cosmos/gogoproto v1.7.0
 	github.com/golang/protobuf v1.5.4
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0


### PR DESCRIPTION
Bumps the `x/upgrade` extracted module to require `github.com/cosmos/cosmos-sdk v0.500.0` (was `v0.50.14`).

Go ignores a dependency's own `replace` directives, so without this the published `cosmossdk.io/x/upgrade` module would resolve upstream cosmos-sdk `v0.50.14` instead of the AtomOne `v0.500.0` fork. This was missed in #101.

Verified locally: `go mod verify`, `go build ./...`, and `go test ./...` pass against the SDK.

After merge, the module will be retagged as `x/upgrade/v0.1.5-atomone.3`.

Part of #90.