### PR TITLE
fix(docker): repair Build & Push (removed-module COPYs + image name)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,6 @@
 name: Build & Push
 # Build & Push builds the simapp docker image on every push to main and
-# and pushes the image to https://ghcr.io/cosmos/simapp
+# and pushes the image to https://ghcr.io/atomone-hub/simapp
 on:
   pull_request:
     paths:
@@ -26,7 +26,7 @@ env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
-  IMAGE_NAME: cosmos/simapp
+  IMAGE_NAME: atomone-hub/simapp
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # > docker run -it -p 26657:26657 -p 26656:26656 -v ~/.simappcli:/root/.simapp simapp simd keys add foo
 # > docker run -it -p 26657:26657 -p 26656:26656 -v ~/.simappcli:/root/.simapp simapp simd keys list
 #
-# This image is pushed to the GHCR as https://ghcr.io/cosmos/simapp
+# This image is pushed to the GHCR as https://ghcr.io/atomone-hub/simapp
 
 FROM golang:1.24-alpine AS build-env
 
@@ -23,9 +23,6 @@ WORKDIR /go/src/github.com/cosmos/cosmos-sdk
 
 # optimization: if go.sum didn't change, docker will use cached image
 COPY go.mod go.sum ./
-COPY collections/go.mod collections/go.sum ./collections/
-COPY store/go.mod store/go.sum ./store/
-COPY log/go.mod log/go.sum ./log/
 
 RUN go mod download
 


### PR DESCRIPTION
## Problem

The **Build & Push** workflow (`docker.yml`) fails on every `main` push and on release tags:

```
ERROR: failed to compute cache key: "/log/go.sum": not found
```

The `Dockerfile` still copies `go.mod`/`go.sum` for `collections`, `store`, and `log` — non-forked modules that were **removed** in #22/#25. The build fails on the first missing one. This has been broken since those modules were removed; it surfaced loudly on the `v0.500.0` tag.

## Fix

- Remove the three stale `COPY <module>/go.mod <module>/go.sum` lines. The main module's `go mod download` doesn't reference them (no local `replace` to those dirs), and `COPY . .` still brings the full source for `make build`.
- Rename the published image `ghcr.io/cosmos/simapp` → `ghcr.io/atomone-hub/simapp` (the `cosmos` ghcr namespace isn't writable by this org; the build failed before the push, so this was latent). **Adjust the name if you'd prefer something else.**

CI on this PR runs the docker build (`push: false` for PRs), so it verifies the Dockerfile builds.

Surfaced while finalizing #90.