### PR TITLE
fix(ci): drop goreleaser --release-notes flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Create release
         uses: goreleaser/goreleaser-action@v3
         with:
-          args: release --clean --release-notes ./RELEASE_NOTES.md
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,8 +3,8 @@ project_name: cosmos-sdk
 
 release:
   github:
-    owner: cosmos
-    name: cosmos-sdk
+    owner: atomone-hub
+    name: atomone-sdk
 
 builds:
   - skip: true


### PR DESCRIPTION
## Problem

The **Release** workflow (triggered by the `v0.500.0` tag) failed:

```
⨯ release failed: open ./RELEASE_NOTES.md: no such file or directory
```

`release.yml` runs goreleaser with `--release-notes ./RELEASE_NOTES.md`, but this fork has no `RELEASE_NOTES.md` and it isn't part of its release flow. The workflow only fires on final `vX.Y.Z` tags (not `-rc.*`), so the gap stayed hidden through the rc's.

## Fixes

1. **Drop `--release-notes`** — goreleaser then auto-generates the notes from its `changelog` config (`changelog.disable: false`) instead of requiring a hand-written file.
   ```diff
   -          args: release --clean --release-notes ./RELEASE_NOTES.md
   +          args: release --clean
   ```
2. **Point the release target at the fork** — `.goreleaser.yml` hard-coded `release.github.owner: cosmos / name: cosmos-sdk` (upstream), so goreleaser would 403 publishing with this fork's token. Now `atomone-hub / atomone-sdk`.

## Follow-up (not in this PR)

The existing `v0.500.0` tag points to a commit with the old workflow; tag-triggered runs use the workflow **at the tagged commit**, so after merge the tag must be re-pointed to the merged commit for these fixes to take effect.

Part of #90.