### PR TITLE
feat(x/gov): reject proposals with self-executing `authz.MsgExec` messages (granter == grantee == authority)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+* (x/gov) [#106](https://github.com/atomone-hub/cosmos-sdk/pull/106) Reject proposals with self-executing authz.MsgExec messages (granter == grantee == authority).
+
 ### Bug Fixes
 
 ## [v0.500.0](https://github.com/atomone-hub/cosmos-sdk/releases/tag/v0.500.0) - 2026-06-22

--- a/x/gov/keeper/common_test.go
+++ b/x/gov/keeper/common_test.go
@@ -22,6 +22,7 @@ import (
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	disttypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/keeper"
@@ -149,6 +150,7 @@ func setupGovKeeperWithStoreKey(t *testing.T, expectations ...func(sdk.Context, 
 	v1.RegisterInterfaces(encCfg.InterfaceRegistry)
 	v1beta1.RegisterInterfaces(encCfg.InterfaceRegistry)
 	banktypes.RegisterInterfaces(encCfg.InterfaceRegistry)
+	authz.RegisterInterfaces(encCfg.InterfaceRegistry)
 
 	// Create MsgServiceRouter, but don't populate it before creating the gov
 	// keeper.
@@ -201,6 +203,7 @@ func setupGovKeeperWithStoreKey(t *testing.T, expectations ...func(sdk.Context, 
 	msr.SetInterfaceRegistry(encCfg.InterfaceRegistry)
 	v1.RegisterMsgServer(msr, keeper.NewMsgServerImpl(govKeeper))
 	banktypes.RegisterMsgServer(msr, nil) // Nil is fine here as long as we never execute the proposal's Msgs.
+	authz.RegisterMsgServer(msr, nil)     // Nil is fine here as long as we never execute the proposal's Msgs.
 
 	return govKeeper, key, acctKeeper, bankKeeper, stakingKeeper, distributionKeeper, encCfg, ctx
 }

--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -35,6 +35,16 @@ func (keeper Keeper) SubmitProposal(ctx context.Context, messages []sdk.Msg, met
 		return v1.Proposal{}, err
 	}
 
+	// Reject proposals containing a self-executing authz.MsgExec (grantee == granter ==
+	// authority). Checked before the per-message routing loop below.
+	selfExec, err := v1.ContainsSelfExecAsAuthority(keeper.cdc, messages, keeper.GetGovernanceAccount(ctx).GetAddress())
+	if err != nil {
+		return v1.Proposal{}, err
+	}
+	if selfExec {
+		return v1.Proposal{}, errorsmod.Wrap(types.ErrInvalidProposalMsg, "governance proposals may not contain a self-executing authz.MsgExec (grantee == granter == authority)")
+	}
+
 	// Will hold a comma-separated string of all Msg type URLs.
 	msgsStr := ""
 

--- a/x/gov/keeper/proposal_test.go
+++ b/x/gov/keeper/proposal_test.go
@@ -10,8 +10,11 @@ import (
 
 	"cosmossdk.io/collections"
 
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
@@ -155,6 +158,60 @@ func (suite *KeeperTestSuite) TestSubmitProposal() {
 		suite.Require().NoError(err)
 		_, err = suite.govKeeper.SubmitProposal(suite.ctx, []sdk.Msg{prop}, tc.metadata, "title", "", suite.addrs[0])
 		suite.Require().True(errors.Is(tc.expectedErr, err), "tc #%d; got: %v, expected: %v", i, err, tc.expectedErr)
+	}
+}
+
+// TestSubmitProposalSelfExec verifies how SubmitProposal treats authz.MsgExec proposal
+// messages: a self-executing one (grantee == granter == authority, possibly nested,
+// up to the nesting-depth cap) is rejected, while a valid cross-account MsgExec — grantee
+// is the authority but the inner message is signed by another account — is accepted.
+func (suite *KeeperTestSuite) TestSubmitProposalSelfExec() {
+	govAddr := suite.govKeeper.GetGovernanceAccount(suite.ctx).GetAddress()
+	other := suite.addrs[1]
+
+	pack := func(msg sdk.Msg) *codectypes.Any {
+		a, err := codectypes.NewAnyWithValue(msg)
+		suite.Require().NoError(err)
+		return a
+	}
+	// nestSelfExec wraps an authority-signed amendment in `depth` authz.MsgExec layers,
+	// each with grantee == authority (a self-executing chain).
+	nestSelfExec := func(depth int) sdk.Msg {
+		cur := pack(v1.NewMsgProposeConstitutionAmendment(govAddr, "@@ -1 +1 @@\n-\n+Test"))
+		var exec *authz.MsgExec
+		for i := 0; i < depth; i++ {
+			exec = &authz.MsgExec{Grantee: govAddr.String(), Msgs: []*codectypes.Any{cur}}
+			cur = pack(exec)
+		}
+		return exec
+	}
+	crossAccount := &authz.MsgExec{
+		Grantee: govAddr.String(),
+		Msgs:    []*codectypes.Any{pack(banktypes.NewMsgSend(other, govAddr, sdk.NewCoins()))},
+	}
+
+	testCases := []struct {
+		name        string
+		msgs        []sdk.Msg
+		expErr      error // nil => expect success
+		errContains string
+	}{
+		{"direct self-exec is rejected", []sdk.Msg{nestSelfExec(1)}, types.ErrInvalidProposalMsg, "self-executing authz.MsgExec"},
+		{"nested self-exec is rejected", []sdk.Msg{nestSelfExec(3)}, types.ErrInvalidProposalMsg, "self-executing authz.MsgExec"},
+		{"self-exec at depth cap is rejected", []sdk.Msg{nestSelfExec(8)}, types.ErrInvalidProposalMsg, "self-executing authz.MsgExec"},
+		{"self-exec beyond depth cap errors", []sdk.Msg{nestSelfExec(9)}, types.ErrInvalidProposalMsg, "authz nesting depth exceeded"},
+		{"valid cross-account MsgExec passes", []sdk.Msg{crossAccount}, nil, ""},
+	}
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			_, err := suite.govKeeper.SubmitProposal(suite.ctx, tc.msgs, "", "title", "summary", suite.addrs[0])
+			if tc.expErr == nil {
+				suite.Require().NoError(err)
+				return
+			}
+			suite.Require().ErrorIs(err, tc.expErr)
+			suite.Require().ErrorContains(err, tc.errContains)
+		})
 	}
 }
 

--- a/x/gov/types/v1/msgs.go
+++ b/x/gov/types/v1/msgs.go
@@ -1,12 +1,20 @@
 package v1
 
 import (
+	errorsmod "cosmossdk.io/errors"
+
+	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 )
+
+// maxAuthzNestingDepth bounds how deep authz.MsgExec wrappers are inspected
+// in a proposal message. Nesting depth beyond this limit is rejected altogether.
+const maxAuthzNestingDepth = 8
 
 var (
 	_, _, _, _, _, _, _, _, _, _, _, _, _ sdk.Msg                            = &MsgSubmitProposal{}, &MsgDeposit{}, &MsgVote{}, &MsgVoteWeighted{}, &MsgExecLegacyContent{}, &MsgUpdateParams{}, &MsgProposeConstitutionAmendment{}, &MsgProposeLaw{}, &MsgCreateGovernor{}, &MsgEditGovernor{}, &MsgDelegateGovernor{}, &MsgUndelegateGovernor{}, &MsgUpdateGovernorStatus{}
@@ -200,4 +208,72 @@ func (msg MsgUpdateGovernorStatus) ValidateBasic() error {
 		return types.ErrInvalidGovernorStatus.Wrap(msg.GetStatus().String())
 	}
 	return nil
+}
+
+// ContainsSelfExecAsAuthority reports whether any of msgs is, or nests through
+// authz.MsgExec wrappers whose grantee is the authority, a leaf message signed by the
+// authority itself — i.e. an authz.MsgExec with grantee == granter == authority. Such
+// a message executes its inner content without an authz grant and is able to bypass
+// proposals inspections (e.g.proposal-kind classification), and has no legitimate use
+// in a governance proposal.
+func ContainsSelfExecAsAuthority(cdc codec.Codec, msgs []sdk.Msg, authority sdk.AccAddress) (bool, error) {
+	for _, msg := range msgs {
+		exec, ok := msg.(*authz.MsgExec)
+		if !ok {
+			continue
+		}
+		reaches, err := execReachesAuthority(cdc, exec, authority, 1)
+		if err != nil {
+			return false, err
+		}
+		if reaches {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// execReachesAuthority reports whether exec is a self-executing chain reaching a leaf
+// signed by authority. The chain is self-executing only while every authz.MsgExec layer
+// has authority as its grantee (authz dispatches inner messages without a grant only when
+// granter == grantee). maxAuthzNestingDepth bounds the nesting inspected.
+func execReachesAuthority(cdc codec.Codec, exec *authz.MsgExec, authority sdk.AccAddress, depth int) (bool, error) {
+	if depth > maxAuthzNestingDepth {
+		return false, errorsmod.Wrap(types.ErrInvalidProposalMsg, "authz nesting depth exceeded")
+	}
+	grantee, err := sdk.AccAddressFromBech32(exec.Grantee)
+	if err != nil {
+		return false, err
+	}
+	if !grantee.Equals(authority) {
+		// A grant would be required at this layer; the chain cannot self-execute.
+		return false, nil
+	}
+	for _, anyInner := range exec.Msgs {
+		var inner sdk.Msg
+		if err := cdc.UnpackAny(anyInner, &inner); err != nil {
+			// An inner message the codec cannot unpack can never execute as the
+			// authority (authz must unpack it to dispatch it), so it cannot be a
+			// self-exec leaf — skipping it is safe.
+			continue
+		}
+		if innerExec, ok := inner.(*authz.MsgExec); ok {
+			reaches, err := execReachesAuthority(cdc, innerExec, authority, depth+1)
+			if err != nil {
+				return false, err
+			}
+			if reaches {
+				return true, nil
+			}
+			continue
+		}
+		signers, _, err := cdc.GetMsgV1Signers(inner)
+		if err != nil {
+			return false, err
+		}
+		if len(signers) == 1 && authority.Equals(sdk.AccAddress(signers[0])) {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/x/gov/types/v1/msgs_test.go
+++ b/x/gov/types/v1/msgs_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
@@ -69,6 +71,77 @@ func TestMsgSubmitProposal_GetSignBytes(t *testing.T) {
 			bz, err := pc.MarshalAminoJSON(msg)
 			require.NoError(t, err)
 			require.Equal(t, tc.expSignBz, string(bz))
+		})
+	}
+}
+
+func TestContainsSelfExecAsAuthority(t *testing.T) {
+	encCfg := moduletestutil.MakeTestEncodingConfig()
+	v1.RegisterInterfaces(encCfg.InterfaceRegistry)
+	authz.RegisterInterfaces(encCfg.InterfaceRegistry)
+	banktypes.RegisterInterfaces(encCfg.InterfaceRegistry)
+	cdc := encCfg.Codec
+
+	authority := addrs[0]
+	other := addrs[1]
+	// amendment's signer is its Authority field (set to authority).
+	amendment := v1.NewMsgProposeConstitutionAmendment(authority, "@@ -1 +1 @@\n-\n+Test")
+	// send's signer is its FromAddress (set to other).
+	send := banktypes.NewMsgSend(other, authority, coinsPos)
+
+	pack := func(msg sdk.Msg) *types.Any {
+		a, err := types.NewAnyWithValue(msg)
+		require.NoError(t, err)
+		return a
+	}
+	// nest wraps leaf in `depth` authz.MsgExec layers, each with grantee == authority.
+	nest := func(depth int, leaf sdk.Msg) sdk.Msg {
+		cur := pack(leaf)
+		var exec *authz.MsgExec
+		for i := 0; i < depth; i++ {
+			exec = &authz.MsgExec{Grantee: authority.String(), Msgs: []*types.Any{cur}}
+			cur = pack(exec)
+		}
+		return exec
+	}
+
+	tests := []struct {
+		name    string
+		msgs    []sdk.Msg
+		wantHit bool
+		wantErr bool
+	}{
+		{"direct self-exec amendment", []sdk.Msg{nest(1, amendment)}, true, false},
+		{"nested self-exec (3 layers)", []sdk.Msg{nest(3, amendment)}, true, false},
+		{"self-exec at depth cap (8)", []sdk.Msg{nest(8, amendment)}, true, false},
+		{"depth beyond cap (9)", []sdk.Msg{nest(9, amendment)}, false, true},
+		{
+			"cross-account wrapped (inner signed by other)",
+			[]sdk.Msg{&authz.MsgExec{Grantee: authority.String(), Msgs: []*types.Any{pack(send)}}},
+			false, false,
+		},
+		{
+			"grantee not authority (chain broken)",
+			[]sdk.Msg{&authz.MsgExec{Grantee: other.String(), Msgs: []*types.Any{pack(amendment)}}},
+			false, false,
+		},
+		{"plain message, no MsgExec", []sdk.Msg{amendment}, false, false},
+		{
+			"mixed inner: one cross-account, one self-exec leaf",
+			[]sdk.Msg{&authz.MsgExec{Grantee: authority.String(), Msgs: []*types.Any{pack(send), pack(amendment)}}},
+			true, false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hit, err := v1.ContainsSelfExecAsAuthority(cdc, tc.msgs, authority)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "authz nesting depth exceeded")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantHit, hit)
 		})
 	}
 }


### PR DESCRIPTION
This PR adds inspection of proposals at `SubmitProposal` time to detect and reject nested `authz.MsgExec` msgs that are "self-executing" i.e. where `granter == grantee == authority`. 

The `authz` module accepts `MsgExec` where `granter == grantee` automatically without the need for an existing grant. In the case of gov proposals, where `authority` is the only designated account that can execute proposal msgs, such proposals serve no purpose and can actually result in a bypass of existing rules and logic that inspect proposals such as pass threshold determination based on the proposal kind (amendment, law, ...)

A maximum depth constant (set at 8 at the time of this PR) bounds the maximum nesting depth and result in rejection if this threshold is exceeded.